### PR TITLE
Drive hero and contact text from CMS profile

### DIFF
--- a/src/components/sections/contact/Contact1.js
+++ b/src/components/sections/contact/Contact1.js
@@ -1,8 +1,10 @@
 import React, { useRef, useState } from "react";
 import FormSelect from "@/components/shared/Inputs/FormSelect";
 import { sendContactEmail } from "@/libs/sendContactEmail";
+import getProfile from "@/libs/getProfile";
 
 const Contact1 = () => {
+  const profile = getProfile();
   const form = useRef();
   const [formData, setFormData] = useState({
     first_name: "",
@@ -196,10 +198,10 @@ const Contact1 = () => {
                         Phone
                       </p>
                       <a
-                        href="tel:0123456789"
+                        href={`tel:${profile.phone.replace(/\s/g, "")}`}
                         className="text-primary-color-light dark:text-white-color text-lg lg:text-xl font-medium hover:text-primary-color"
                       >
-                        +91 9790427138
+                        {profile.phone}
                       </a>
                     </div>
                   </li>
@@ -215,10 +217,10 @@ const Contact1 = () => {
                         Email
                       </p>
                       <a
-                        href="mailto:contact@devmohan.in"
+                        href={`mailto:${profile.email}`}
                         className="text-primary-color-light dark:text-white-color text-lg lg:text-xl font-medium hover:text-primary-color"
                       >
-                        contact@devmohan.in
+                        {profile.email}
                       </a>
                     </div>
                   </li>
@@ -237,8 +239,7 @@ const Contact1 = () => {
                         href="#"
                         className="text-primary-color-light dark:text-white-color text-lg lg:text-xl font-medium hover:text-primary-color"
                       >
-                        Hyderabad, Telangana, <br />
-                        India
+                        {profile.location}
                       </a>
                     </div>
                   </li>

--- a/src/components/sections/heros/Hero.js
+++ b/src/components/sections/heros/Hero.js
@@ -2,8 +2,10 @@ import ButtonSeondary from "@/components/shared/buttons/ButtonSeondary";
 import FunFact from "@/components/shared/fun-fact/FunFact";
 import Socials from "@/components/shared/socials/Socials";
 import Image from "next/image";
+import getProfile from "@/libs/getProfile";
 
 const Hero = () => {
+  const profile = getProfile();
   return (
     <section className="hero-section relative pt-130px lg:pt-40 xl:pt-200px pb-10 md:pb-30px lg:pb-50px after:absolute after:top-0 after:right-0 after:w-322px after:h-308px after:blur-[150px] after:rounded-50% after:bg-gradient-circle after:-z-1 after:-mt-5% after:-mr-5% overflow-hidden">
       {/* <!-- intro tex --> */}
@@ -18,11 +20,10 @@ const Hero = () => {
         <div className="hidded md:grid md:grid-cols-2 md:items-center gap-30px">
           <div>
             <h4 className="text-seondary-color dark:text-body-color text-size-22 md:text-size-25 lg:text-4xl lg:leading-1.5 font-bold mb-1.5 xl:mb-10px">
-              I am Mohan Sagar
+              I am {profile.firstName}
             </h4>
             <h1 className="text-size-35 md:text-size-38 lg:text-size-50 xl:text-6xl 2xl:text-size-65 bg-gradient-text-light dark:bg-gradient-text bg-clip-text xl:leading-1.2 text-transparent mb-15px">
-              Next-Level Web <br />
-              Developer.
+              {profile.headline}.
             </h1>
             <div className="flex md:hidden justify-center items-center my-30px">
               <Image
@@ -34,13 +35,12 @@ const Hero = () => {
               />
             </div>
             <p className="text-xl leading-1.5 text-primary-color-light dark:text-body-color max-w-540px">
-              I break down complex user experinece problems to create integritiy
-              focussed solutions that connect billions of people
+              {profile.bio}
             </p>
             {/* <!-- action and social --> */}
             <div className="flex items-center gap-30px lg:gap-25px mt-5 flex-wrap lg:flex-nowrap md:mt-30px lg:mt-50px">
               <div>
-                <ButtonSeondary url="resume.pdf">
+                <ButtonSeondary url={profile.resumeUrl || "resume.pdf"}>
                   Download CV{" "}
                   <i className="flaticon-download ml-0.5 text-size-17"></i>
                 </ButtonSeondary>

--- a/src/libs/getProfile.js
+++ b/src/libs/getProfile.js
@@ -1,0 +1,21 @@
+import { getContent } from "./contentStore";
+
+// Fallback mirrors the canonical profile so a failed fetch renders the
+// same content the CMS would provide.
+const fallback = {
+  firstName: "Mohan Sagar",
+  lastName: "Killamsetty",
+  headline: "AI & Frontend Software Engineer",
+  bio: "I'm a Senior Software Engineer with 9+ years building AI-powered products and high-performance frontend systems at scale—specializing in LLM integrations, agentic workflows, and real-time interfaces. At Invesco I led IVYGPT, an internal AI platform used by 8,000+ users that cut report analysis from 30 days to 30 minutes. At Reliance Jio I led 10 engineers on platforms serving 5M+ users, improving performance ~90%. Now at ServiceNow I build agentic AI platforms with React, Next.js, Python and Node.",
+  avatar: "",
+  email: "contact@devmohan.in",
+  phone: "+91 9790427138",
+  location: "Hyderabad, Telangana, India",
+  resumeUrl: "resume.pdf",
+};
+
+const getProfile = () => {
+  return getContent("profile") || fallback;
+};
+
+export default getProfile;


### PR DESCRIPTION
## Summary
- Hero: "I am {firstName}", headline from profile ("AI & Frontend Software Engineer"), tagline paragraph now profile.bio (replaces template filler with typos: "experinece", "integritiy focussed"), Download CV → profile.resumeUrl
- Contact: email, phone (incl. tel: href), address from profile
- New `src/libs/getProfile.js` with a fallback mirroring canonical values

Closes the last content gaps on devmohan.in — everything except blogs and site furniture is now CMS-driven.

## Test plan
- [x] `next build` green
- [x] Headless Chromium on local prod build: hero shows profile name/headline/bio, contact shows email + phone with tel: link, old filler strings absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)