### PR TITLE
Resolve admin-uploaded resume paths to admin file host

### DIFF
--- a/scripts/test-content-mapping.mjs
+++ b/scripts/test-content-mapping.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import {
-  mapSkills, mapResume, mapPortfolio, mapServices, mapSocials, mapTestimonials, RAW_BASE,
+  mapSkills, mapResume, mapPortfolio, mapServices, mapSocials, mapTestimonials, RAW_BASE, resolveFileUrl,
 } from '../src/libs/contentMapping.js';
 
 const bundledResume = JSON.parse(readFileSync('public/fakedata/resume.json', 'utf8'));
@@ -73,5 +73,11 @@ assert.deepEqual(socials[1], { id: 'youtube', iconName: 'fa-brands fa-youtube', 
 // testimonials
 const t = mapTestimonials({ items: [{ author: 'A', role: 'R', quote: 'Q', avatar: '/images/testimonials/a.jpg' }] })[0];
 assert.deepEqual(t, { id: 1, authorName: 'A', authorDesig: 'R', img: `${RAW_BASE}/images/testimonials/a.jpg`, desc: 'Q' });
+
+// file-url resolution
+import assert2 from 'node:assert/strict';
+assert2.equal(resolveFileUrl('/files/resume.pdf'), 'https://admin.devmohan.in/files/resume.pdf');
+assert2.equal(resolveFileUrl('https://x.y/r.pdf'), 'https://x.y/r.pdf');
+assert2.equal(resolveFileUrl(''), '');
 
 console.log('content mapping OK');

--- a/src/libs/contentMapping.js
+++ b/src/libs/contentMapping.js
@@ -1,6 +1,15 @@
 // Pure canonical→presentational mapping. No JSON imports and no Next.js
 // dependencies here: plain Node must be able to import this file for tests.
 export const RAW_BASE = "https://raw.githubusercontent.com/mohansagark/portfolio-data/main";
+// Uploaded files (e.g. the resume PDF) are served by the admin site's Vercel
+// deployment, which serves the portfolio-data repo statically with proper
+// content types (GitHub raw would force a download).
+export const FILES_BASE = "https://admin.devmohan.in";
+
+// Repo-relative file paths (from the admin's file-upload widget) resolve to
+// the admin file host; absolute URLs pass through.
+export const resolveFileUrl = (p) =>
+  p && p.startsWith("/") ? `${FILES_BASE}${p}` : p || "";
 
 const img = (p) => (p ? `${RAW_BASE}${p}` : "");
 

--- a/src/libs/portfolioData.js
+++ b/src/libs/portfolioData.js
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   RAW_BASE,
+  resolveFileUrl,
   mapSkills,
   mapResume,
   mapPortfolio,
@@ -54,6 +55,11 @@ export async function fetchAllContent() {
   if (canon.services) bundle.services = mapServices(canon.services, bundled("services"));
   if (canon.socials) bundle.socials = mapSocials(canon.socials);
   if (canon.testimonials) bundle.testimonials = mapTestimonials(canon.testimonials);
-  if (canon.profile) bundle.profile = canon.profile;
+  if (canon.profile) {
+    bundle.profile = {
+      ...canon.profile,
+      resumeUrl: resolveFileUrl(canon.profile.resumeUrl),
+    };
+  }
   return bundle;
 }


### PR DESCRIPTION
## Summary
- Profile's resumeUrl is now a file-upload widget in the Decap admin; uploads land in portfolio-data's `files/` and store a repo-relative path
- Adds `resolveFileUrl`: repo-relative paths resolve to `https://admin.devmohan.in` (serves the repo statically with proper PDF content-type; GitHub raw would force a download); absolute URLs pass through
- Hero's Download CV button now always serves the latest uploaded resume

Verified locally: button href resolves to the file Mohan already uploaded via the admin (`/files/mohansagar_9years_aiengineer.pdf`, serving HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)