### PR TITLE
Fix blog post rendering: layout, typography, code blocks, takeaways, byline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@eslint/js": "^9.31.0",
+        "@tailwindcss/typography": "^0.5.20",
         "eslint": "^9",
         "eslint-config-next": "15.1.2",
         "gray-matter": "^2.0.1",
@@ -1086,6 +1087,33 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@eslint/js": "^9.31.0",
+    "@tailwindcss/typography": "^0.5.20",
     "eslint": "^9",
     "eslint-config-next": "15.1.2",
     "gray-matter": "^2.0.1",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2669,3 +2669,91 @@ html {
 }
 
 /* !END: Theme cursor CSS */
+
+/* ==========================================================================
+   Blog post body — code blocks + highlight.js (github-dark) syntax colors.
+   Post HTML is precompiled with rehype-highlight, which emits `hljs`/`hljs-*`
+   classes; these rules give code a distinct box and colored tokens.
+   ========================================================================== */
+.prose pre {
+  background: #0d1117;
+  color: #e6edf3;
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  border: 1px solid #30363d;
+  overflow-x: auto;
+  font-size: 0.9em;
+  line-height: 1.6;
+}
+.prose pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  font-weight: 400;
+}
+/* inline code (not inside a pre) */
+.prose :not(pre) > code {
+  background: rgba(110, 118, 129, 0.22);
+  color: inherit;
+  padding: 0.15em 0.4em;
+  border-radius: 0.35rem;
+  font-size: 0.88em;
+  font-weight: 500;
+}
+/* strip prose's default backtick pseudo-elements around inline code */
+.prose :not(pre) > code::before,
+.prose :not(pre) > code::after {
+  content: none;
+}
+
+/* highlight.js github-dark token palette */
+.hljs-comment,
+.hljs-quote {
+  color: #8b949e;
+  font-style: italic;
+}
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-doctag {
+  color: #ff7b72;
+}
+.hljs-string,
+.hljs-meta .hljs-string,
+.hljs-regexp,
+.hljs-addition {
+  color: #a5d6ff;
+}
+.hljs-number,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-attr,
+.hljs-attribute,
+.hljs-variable,
+.hljs-template-variable {
+  color: #79c0ff;
+}
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.function_,
+.hljs-section {
+  color: #d2a8ff;
+}
+.hljs-built_in,
+.hljs-type,
+.hljs-name {
+  color: #ffa657;
+}
+.hljs-tag {
+  color: #7ee787;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: 700;
+}
+.hljs-deletion {
+  color: #ffdcd7;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2707,6 +2707,11 @@ html {
   content: none;
 }
 
+/* the global `a { display: inline-block }` breaks inline links inside prose */
+.prose a {
+  display: inline;
+}
+
 /* highlight.js github-dark token palette */
 .hljs-comment,
 .hljs-quote {

--- a/src/components/sections/blog-details/BlogDetailsPrimary.js
+++ b/src/components/sections/blog-details/BlogDetailsPrimary.js
@@ -1,5 +1,4 @@
 import BlogSidebar from "@/components/shared/sidebar/BlogSidebar";
-import AuthorDisplay from "@/components/shared/AuthorDisplay";
 import countCommentLength from "@/libs/countCommentLength";
 import makePath from "@/libs/makePath";
 import sliceText from "@/libs/sliceText";
@@ -15,199 +14,117 @@ const BlogDetailsPrimary = ({
   isNextBlog,
 }) => {
   const {
-    // id, // unused but kept for future reference
-    detailsImg,
     title,
     desc,
-    desc1,
-    desc2,
-    desc3,
     blogTopList,
     category,
     author,
     comments,
     tags,
+    keyTakeaways,
   } = blog ? blog : {};
-  const { title: prevBlogTitle, img: prevBlogImg } = pervblog || {};
-  const { title: nextBlogTitle, img: nextBlogImg } = nextblog || {};
+  const { title: prevBlogTitle } = pervblog || {};
+  const { title: nextBlogTitle } = nextblog || {};
+
   return (
     <section id="blogs">
       <div className="py-60px md:py-20 lg:py-100px xl:py-30 dark:bg-black-color">
         <div className="container">
           <div className="lg:grid lg:gap-6 lg:grid-cols-12">
-            {/* <!-- blogs details --> */}
-            <div className="lg:col-start-1 lg:col-span-8">
-              <article
-                className="group relative flex flex-col items-center wow fadeInUp"
-                data-wow-delay=".3s"
-              >
-                <div className="rounded-lg relative overflow-hidden">
-                  {/* Blog detail image removed as requested */}
+            {/* <!-- blog details --> */}
+            <div className="lg:col-start-1 lg:col-span-8 min-w-0">
+              <article className="wow fadeInUp" data-wow-delay=".3s">
+                {/* category */}
+                {category ? (
                   <Link
                     href={`/blogs?category=${makePath(category)}`}
                     className="text-size-13 uppercase px-15px py-10px rounded-50px leading-1 inline-block mb-4 text-white-color bg-gradient-secondary-2 bg-200 hover:bg-100"
                   >
                     {category}
                   </Link>
+                ) : null}
 
-                  <div className="pt-25px md:pt-30px">
-                    <div className="transition-all duration-500">
-                      <div className="relative z-0">
-                        <div className="relative z-10">
-                          <ul className="flex flex-wrap gap-x-15px md:gap-x-25px gap-y-10px items-center mb-15px md:mb-5">
-                            {blogTopList?.length
-                              ? blogTopList?.map(
-                                  ({ iconName, name, path }, idx) => (
-                                    <li
-                                      key={1000 + idx}
-                                      className="text-primary-color dark:text-white-color "
-                                    >
-                                      <i
-                                        className={`${iconName} mr-1 text-primary-color transition-all duration-500`}
-                                      ></i>{" "}
-                                      {path ? (
-                                        <Link
-                                          href={`/blogs?author=${makePath(
-                                            author
-                                          )}`}
-                                          className="text-primary-color dark:text-white-color hover:text-primary-color transition-all duration-500 capitalize"
-                                        >
-                                          By {name}
-                                        </Link>
-                                      ) : (
-                                        name
-                                      )}
-                                    </li>
-                                  )
-                                )
-                              : ""}
-                            {/* Comments count as separate item */}
-                            {comments && comments.length > 0 && (
-                              <li className="text-primary-color dark:text-white-color">
-                                <i className="fa-regular fa-comments mr-1 text-primary-color transition-all duration-500"></i>{" "}
-                                <Link
-                                  href="#comment-reply"
-                                  className="text-primary-color dark:text-white-color hover:text-primary-color transition-all duration-500"
-                                >
-                                  Comments ({countCommentLength(comments)})
-                                </Link>
-                              </li>
-                            )}
-                          </ul>
-                          <h3 className="mb-15px md:mb-5">
-                            <span className="text-primary-color dark:text-white-color capitalize relative z-0 text-size-22 md:text-3xl font-bold">
-                              {title}
-                            </span>
-                          </h3>
-                          <p className="text-primary-color-light dark:text-white-color mb-15px md:mb-5">
-                            {desc}
-                          </p>
-                          <p className="text-primary-color-light dark:text-white-color mb-15px md:mb-5">
-                            {desc1}
-                          </p>
-                          <p className="text-primary-color-light dark:text-white-color mb-15px md:mb-5">
-                            {desc2}
-                          </p>
-                          {/* <!-- blog quote --> */}
-                          <div className="rounded-lg relative overflow-hidden bg-primary-color-light">
-                            <blockquote className="py-25px px-15px md:p-30px relative block before:content-['\f10e'] before:block before:text-size-40 before:leading-none before:font-fontawesome before:font-light before:relative before:mb-3">
-                              <div className="transition-all duration-500">
-                                <div className="relative z-0">
-                                  <div className="relative z-10">
-                                    <p className="text-white-color mb-15px">
-                                      {desc3 ||
-                                        "Explore the insights and key takeaways from this comprehensive guide."}
-                                    </p>
-                                    <p className="text-white-color mb-2">
-                                      <cite className="text-xl relative inline-block before:inline-block before:w-[35px] before:h-0.5 before:bg-primary-color before:rounded-[2px] before:relative before:-top-[6px] before:mr-15px">
-                                        <AuthorDisplay
-                                          author={author || "Agent Bot"}
-                                          className="text-white-color"
-                                        />
-                                      </cite>
-                                    </p>
-                                  </div>
-                                </div>
-                              </div>
-                            </blockquote>
-                          </div>
-                          {/* <!-- post body: precompiled, sanitized HTML from portfolio-blog, styled by Tailwind Typography --> */}
-                          <article
-                            className="prose prose-lg dark:prose-invert max-w-none mb-5 prose-headings:text-primary-color-light dark:prose-headings:text-white-color prose-p:text-primary-color-light dark:prose-p:text-white-color prose-a:text-primary-color prose-li:text-primary-color-light dark:prose-li:text-white-color"
-                            dangerouslySetInnerHTML={{ __html: blog?.html || "" }}
-                          />
+                {/* meta: date, author, comments */}
+                <ul className="flex flex-wrap gap-x-15px md:gap-x-25px gap-y-10px items-center mb-15px md:mb-5">
+                  {blogTopList?.length
+                    ? blogTopList.map(({ iconName, name, path }, idx) => (
+                        <li
+                          key={1000 + idx}
+                          className="text-primary-color dark:text-white-color"
+                        >
+                          <i
+                            className={`${iconName} mr-1 text-primary-color transition-all duration-500`}
+                          ></i>{" "}
+                          {path ? (
+                            <Link
+                              href={`/blogs?author=${makePath(author)}`}
+                              className="text-primary-color dark:text-white-color hover:text-primary-color transition-all duration-500 capitalize"
+                            >
+                              By {name}
+                            </Link>
+                          ) : (
+                            name
+                          )}
+                        </li>
+                      ))
+                    : ""}
+                  {comments && comments.length > 0 && (
+                    <li className="text-primary-color dark:text-white-color">
+                      <i className="fa-regular fa-comments mr-1 text-primary-color transition-all duration-500"></i>{" "}
+                      <Link
+                        href="#comment-reply"
+                        className="text-primary-color dark:text-white-color hover:text-primary-color transition-all duration-500"
+                      >
+                        Comments ({countCommentLength(comments)})
+                      </Link>
+                    </li>
+                  )}
+                </ul>
 
-                          {/* <!-- keypoint --> */}
-                          <div className="mb-5">
-                            <h5 className="mb-10px mt-5 md:mt-30px">
-                              <span className="text-primary-color-light dark:text-white-color capitalize relative z-0 text-size-15 md:text-base lg:text-lg font-bold">
-                                Key Points
-                              </span>
-                            </h5>
-                            <ul>
-                              {blog?.keyTakeaways?.length ? (
-                                blog.keyTakeaways.map((takeaway, idx) => (
-                                  <li
-                                    key={idx}
-                                    className="pl-25px mb-10px relative before:content-['\f058'] before:font-fontawesome before:absolute before:left-0 before:top-0 before:text-primary-color before:font-bold"
-                                  >
-                                    <span className="text-primary-color-light dark:text-white-color">
-                                      {takeaway}
-                                    </span>
-                                  </li>
-                                ))
-                              ) : (
-                                <>
-                                  <li className="pl-25px mb-10px relative before:content-['\f058'] before:font-fontawesome before:absolute before:left-0 before:top-0 before:text-primary-color before:font-bold">
-                                    <span className="text-primary-color-light dark:text-white-color">
-                                      Technical insights and practical tips
-                                    </span>
-                                  </li>
-                                  <li className="pl-25px mb-10px relative before:content-['\f058'] before:font-fontawesome before:absolute before:left-0 before:top-0 before:text-primary-color before:font-bold">
-                                    <span className="text-primary-color-light dark:text-white-color">
-                                      Best practices for modern development
-                                    </span>
-                                  </li>
-                                  <li className="pl-25px mb-10px relative before:content-['\f058'] before:font-fontawesome before:absolute before:left-0 before:top-0 before:text-primary-color before:font-bold">
-                                    <span className="text-primary-color-light dark:text-white-color">
-                                      Essential knowledge for developers
-                                    </span>
-                                  </li>
-                                  <li className="pl-25px relative before:content-['\f058'] before:font-fontawesome before:absolute before:left-0 before:top-0 before:text-primary-color before:font-bold">
-                                    <span className="text-primary-color-light dark:text-white-color">
-                                      Practical implementation examples
-                                    </span>
-                                  </li>
-                                </>
-                              )}
-                            </ul>
-                          </div>
-                          {/* <!-- conclusion --> */}
-                          <div>
-                            <h3 className="mb-15px mt-5 md:mt-30px">
-                              <span className="text-primary-color-light dark:text-white-color capitalize relative z-0 text-size-22 md:text-2xl font-bold">
-                                Conclusion
-                              </span>
-                            </h3>
-                            <p className="text-primary-color-light dark:text-white-color mb-15px md:mb-5">
-                              {desc1 ||
-                                "This comprehensive guide provides valuable insights into modern development practices and techniques that can help you build better applications."}
-                            </p>
-                            <p className="text-primary-color-light dark:text-white-color mb-15px md:mb-5">
-                              {desc2 ||
-                                "Stay updated with the latest trends and best practices in software development to advance your career and create meaningful impact in your projects."}
-                            </p>
-                          </div>
-                          {/* <!-- tags and social --> */}
-                        </div>
-                      </div>
-                    </div>
+                {/* title */}
+                <h1 className="text-primary-color dark:text-white-color capitalize text-size-28 md:text-4xl font-bold leading-tight mb-4">
+                  {title}
+                </h1>
+
+                {/* lead / summary */}
+                {desc ? (
+                  <p className="text-primary-color-light dark:text-white-color text-lg leading-relaxed mb-6">
+                    {desc}
+                  </p>
+                ) : null}
+
+                {/* post body: precompiled, sanitized HTML from portfolio-blog */}
+                <div
+                  className="prose prose-lg dark:prose-invert max-w-none break-words prose-headings:text-primary-color-light dark:prose-headings:text-white-color prose-p:text-primary-color-light dark:prose-p:text-white-color prose-strong:text-primary-color-light dark:prose-strong:text-white-color prose-a:text-primary-color prose-li:text-primary-color-light dark:prose-li:text-white-color prose-pre:overflow-x-auto prose-img:rounded-lg"
+                  dangerouslySetInnerHTML={{ __html: blog?.html || "" }}
+                />
+
+                {/* key takeaways (only when present) */}
+                {keyTakeaways?.length ? (
+                  <div className="mt-30px">
+                    <h2 className="text-primary-color-light dark:text-white-color text-2xl font-bold mb-4">
+                      Key Takeaways
+                    </h2>
+                    <ul>
+                      {keyTakeaways.map((takeaway, idx) => (
+                        <li
+                          key={idx}
+                          className="pl-25px mb-10px relative before:content-['\f058'] before:font-fontawesome before:absolute before:left-0 before:top-0 before:text-primary-color before:font-bold"
+                        >
+                          <span className="text-primary-color-light dark:text-white-color">
+                            {takeaway}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
                   </div>
-                </div>
+                ) : null}
               </article>
+
+              {/* <!-- tags and social --> */}
               <div className="flex gap-5 md:gap-x-30px flex-wrap md:flex-nowrap md:items-center md:justify-between py-30px mt-50px border-y border-border-color dark:border-gray-color-3">
                 {/* <!-- tags --> */}
-                <div className="flex gap-x-5 md:gap-x-30px ice">
+                <div className="flex gap-x-5 md:gap-x-30px items-center">
                   <div>
                     <h3>
                       <span className="text-primary-color-light dark:text-white-color capitalize relative z-0 text-size-22 md:text-2xl font-bold">
@@ -218,7 +135,7 @@ const BlogDetailsPrimary = ({
                   <div>
                     <ul className="flex flex-wrap gap-10px items-center">
                       {tags?.length
-                        ? tags?.map((tag, idx) => (
+                        ? tags.map((tag, idx) => (
                             <li key={5000000 + idx} className="font-medium">
                               <Link
                                 href={`/blogs?tag=${makePath(tag)}`}
@@ -237,10 +154,18 @@ const BlogDetailsPrimary = ({
                   <ul className="flex gap-x-5">
                     <li>
                       <Link
-                        href="https://www.facebook.com"
+                        href="https://www.linkedin.com/in/mohansagark/"
                         className="text-primary-color dark:text-white-color border border-primary-color hover:bg-primary-color w-10 h-10 rounded-full flex items-center justify-center overflow-hidden"
                       >
-                        <i className="fa-brands fa-facebook-f"></i>
+                        <i className="fa-brands fa-linkedin-in"></i>
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        href="https://github.com/mohansagark"
+                        className="text-primary-color dark:text-white-color border border-primary-color hover:bg-primary-color w-10 h-10 rounded-full flex items-center justify-center overflow-hidden"
+                      >
+                        <i className="fa-brands fa-github"></i>
                       </Link>
                     </li>
                     <li>
@@ -251,57 +176,40 @@ const BlogDetailsPrimary = ({
                         <i className="fa-brands fa-x-twitter"></i>
                       </Link>
                     </li>
-                    <li>
-                      <Link
-                        href="https://www.linkedin.com"
-                        className="text-primary-color dark:text-white-color border border-primary-color hover:bg-primary-color w-10 h-10 rounded-full flex items-center justify-center overflow-hidden"
-                      >
-                        <i className="fa-brands fa-linkedin-in"></i>
-                      </Link>
-                    </li>
-                    <li>
-                      <Link
-                        href="https://www.pinterest.com"
-                        className="text-primary-color dark:text-white-color border border-primary-color hover:bg-primary-color w-10 h-10 rounded-full flex items-center justify-center overflow-hidden"
-                      >
-                        <i className="fa-brands fa-pinterest-p"></i>
-                      </Link>
-                    </li>
                   </ul>
                 </div>
               </div>
-              {/* <!-- prev next blog --> */}
+
+              {/* <!-- prev / next blog --> */}
               <div className="py-30px border-b border-border-color dark:border-gray-color-3">
                 <div className="flex flex-wrap md:flex-nowrap md:grid gap-5 xl:gap-30px md:grid-cols-2">
-                  {/* <!-- prev blog --> */}
+                  {/* prev */}
                   <div>
                     {isPrevBlog ? (
-                      <>
-                        <div className="group flex gap-x-5 max-w-355px md:max-w-full w-full relative overflow-hidden bg-cream-light-color dark:bg-primary-color-light px-5 py-30px md:px-25px md:py-35px">
-                          <div>
+                      <div className="group flex gap-x-5 max-w-355px md:max-w-full w-full relative overflow-hidden bg-cream-light-color dark:bg-primary-color-light px-5 py-30px md:px-25px md:py-35px">
+                        <div>
+                          <Link
+                            href={isPrevBlog ? `/blogs/${prevId}` : "#"}
+                            className="uppercase text-primary-color mb-1.5 inline-flex gap-2 items-center"
+                          >
+                            <i className="fa-regular fa-angle-double-left"></i>
+                            <span> previous</span>
+                          </Link>
+                          <h3>
                             <Link
                               href={isPrevBlog ? `/blogs/${prevId}` : "#"}
-                              className="uppercase text-primary-color mb-1.5 inline-flex gap-2 items-center"
+                              className="text-primary-color-light dark:text-white-color hover:text-primary-color dark:hover:text-primary-color capitalize relative z-0 text-lg font-medium"
                             >
-                              <i className="fa-regular fa-angle-double-left"></i>
-                              <span> previous</span>
+                              {sliceText(prevBlogTitle, 45)}
                             </Link>
-                            <h3>
-                              <Link
-                                href={isPrevBlog ? `/blogs/${prevId}` : "#"}
-                                className="text-primary-color-light dark:text-white-color hover:text-primary-color dark:hover:text-primary-color capitalize relative z-0 text-lg font-medium"
-                              >
-                                {sliceText(prevBlogTitle, 45)}
-                              </Link>
-                            </h3>
-                          </div>
+                          </h3>
                         </div>
-                      </>
+                      </div>
                     ) : (
                       ""
                     )}
                   </div>
-                  {/* <!-- next blog --> */}
+                  {/* next */}
                   <div className="ml-auto md:ml-0">
                     {isNextBlog ? (
                       <div className="group flex items-start gap-x-5 max-w-355px md:max-w-full w-full relative overflow-hidden bg-cream-light-color dark:bg-primary-color-light px-5 py-30px md:px-25px md:py-35px">
@@ -331,86 +239,6 @@ const BlogDetailsPrimary = ({
                   </div>
                 </div>
               </div>
-
-              {/* <!-- comments --> 
-							<div className="mt-50px">
-								<h3 className="mb-30px pb-3 relative after:w-60px after:h-0.5 after:bg-primary-color after:absolute after:bottom-0 after:left-0 z-1">
-									<span className="text-primary-color-light dark:text-white-color capitalize relative z-0 text-size-22 md:text-3xl font-bold">
-										{countCommentLength(comments)} Comment{countCommentLength(comments) !== 1 ? 's' : ''}
-									</span>
-								</h3>
-								<BlogComments comments={comments} />
-							</div>
-							*/}
-
-              {/* <!-- comment form --> 
-							<div className="pt-50px" id="comment-reply">
-								<h3 className="mb-30px pb-3 relative after:w-60px after:h-0.5 after:bg-primary-color after:absolute after:bottom-0 after:left-0 z-1">
-									<span className="text-primary-color-light dark:text-white-color capitalize relative z-0 text-size-22 md:text-3xl font-bold">
-										Leave a Reply
-									</span>
-								</h3>
-								<p className="text-primary-color-light dark:text-body-color mb-4">
-									I design and code beautifully simple things and i love what i
-									do. Just simple like that!
-								</p>
-								<form>
-									<div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-5">
-										<div>
-											<input
-												type="text"
-												placeholder="Enter Name"
-												className="text-white-color w-full px-5 py-14px border border-gray-color-3 bg-cream-light-color dark:bg-primary-color-light focus:border-primary-color rounded-lg outline-none focus:outline-none transition-all duration-300 placeholder:text-gray-color leading-1"
-											/>
-										</div>
-										<div>
-											<input
-												type="email"
-												placeholder="Enter Email"
-												className="text-white-color w-full px-5 py-14px border border-gray-color-3 bg-cream-light-color dark:bg-primary-color-light focus:border-primary-color rounded-lg outline-none focus:outline-none transition-all duration-300 placeholder:text-gray-color leading-1"
-											/>
-										</div>
-										<div className="sm:col-start-1 sm:col-span-2">
-											<div>
-												<input
-													type="text"
-													placeholder="Enter Website"
-													className="text-white-color w-full px-5 py-14px border border-gray-color-3 bg-cream-light-color dark:bg-primary-color-light focus:border-primary-color rounded-lg outline-none focus:outline-none transition-all duration-300 placeholder:text-gray-color leading-1"
-												/>
-											</div>
-										</div>
-										<div className="sm:col-start-1 sm:col-span-2">
-											<textarea
-												cols="1"
-												rows="10"
-												placeholder="Write Your Comments"
-												className="text-white-color w-full px-5 py-14px border border-gray-color-3 bg-cream-light-color dark:bg-primary-color-light focus:border-primary-color rounded-lg outline-none focus:outline-none transition-all duration-300 placeholder:text-gray-color leading-1"
-											/>
-										</div>
-										<div className="sm:col-start-1 sm:col-span-2 -mt-1">
-											<label
-												htmlFor="agreetocomment"
-												className="text-primary-color-light dark:text-body-color flex items-center gap-2 mb-1"
-											>
-												<input type="checkbox" id="agreetocomment" />
-												<span>
-													Save my name, email, and website in this browser for
-													the next time I comment.
-												</span>
-											</label>
-										</div>
-										<div className="sm:col-start-1 sm:col-span-2">
-											<button
-												type="submit"
-												className="text-size-15 font-bold text-white-color capitalize py-17px px-35px bg-200 bg-gradient-secondary hover:bg-[-100%] rounded-full leading-1 transition-all duration-300"
-											>
-												Post Comment
-											</button>
-										</div>
-									</div>
-								</form>
-							</div>
-							*/}
             </div>
             {/* <!-- sidebar --> */}
             <BlogSidebar />

--- a/src/components/sections/blog-details/BlogDetailsPrimary.js
+++ b/src/components/sections/blog-details/BlogDetailsPrimary.js
@@ -111,9 +111,10 @@ const BlogDetailsPrimary = ({
                           key={idx}
                           className="pl-25px mb-10px relative before:content-['\f058'] before:font-fontawesome before:absolute before:left-0 before:top-0 before:text-primary-color before:font-bold"
                         >
-                          <span className="text-primary-color-light dark:text-white-color">
-                            {takeaway}
-                          </span>
+                          <span
+                            className="text-primary-color-light dark:text-white-color"
+                            dangerouslySetInnerHTML={{ __html: takeaway }}
+                          />
                         </li>
                       ))}
                     </ul>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -695,6 +695,7 @@ module.exports = {
     },
   },
   plugins: [
+    require("@tailwindcss/typography"),
     function ({ addUtilities }) {
       addUtilities({
         ".mask-fade-horizontal": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,6 +209,13 @@
   dependencies:
     tslib "^2.8.0"
 
+"@tailwindcss/typography@^0.5.20":
+  version "0.5.20"
+  resolved "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz"
+  integrity sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==
+  dependencies:
+    postcss-selector-parser "6.0.10"
+
 "@types/estree@^1.0.6":
   version "1.0.9"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz"
@@ -2190,6 +2197,14 @@ postcss-selector-parser@^7.0.0:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
 postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
@@ -2659,7 +2674,7 @@ swiper@^12.2.0:
   resolved "https://registry.npmjs.org/swiper/-/swiper-12.2.0.tgz"
   integrity sha512-K8uXsBZU6ME97Ia3xbBge8IRCnR1lOmIILzvY/jGVic7dSTQ530s3uO8RvXbPUtkkXLWIwmZLRPbtDxRWVAFdg==
 
-tailwindcss@^3.4.1:
+tailwindcss@^3.4.1, "tailwindcss@>=3.0.0 || >=4.0.0 || insiders":
   version "3.4.19"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz"
   integrity sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==


### PR DESCRIPTION
Fixes the broken/text-dump post rendering reported on the live blog.

- **Layout:** removed the `flex items-center` wrapper that centered the full-width prose and overflowed the grid column (content bled off-screen + overlapped the sidebar). Clean block-flow content column.
- **Typography:** `@tailwindcss/typography` was never installed, so every `prose` class was inert — no heading sizes, no paragraph/list spacing, no bullets. Installed + registered the plugin (+ yarn.lock).
- **Code blocks:** added a github-dark highlight.js palette + a distinct code box (the hljs classes had no theme).
- **Key Takeaways:** render `**bold**` as bold (was stripped/literal asterisks).
- **Byline:** always 'Mohan Sagar' (was showing the source article's author).
- Removed leftover template filler (hardcoded blockquote, static Key Points, filler Conclusion, duplicate title/desc).

Verified on the branch preview (mohansagar project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)