### PR TITLE
Serve blog under blog.devmohan.in (middleware + canonical + sitemap)

### DIFF
--- a/src/app/blogs/[slug]/page.js
+++ b/src/app/blogs/[slug]/page.js
@@ -5,11 +5,23 @@ import { notFound } from "next/navigation";
 
 const blogs = getBlogs();
 
-export const metadata = {
-  title: "Blog Details - Dev Mohan - Personal Portfolio React NextJs Template",
-  description:
-    "Blog Details - Dev Mohan - Personal Portfolio React NextJs Template",
-};
+const BLOG_BASE = process.env.NEXT_PUBLIC_BLOG_URL || "https://blog.devmohan.in";
+
+export async function generateMetadata(context) {
+  const { slug } = await context.params;
+  const blog = blogs?.find((b) => b.id === slug);
+  return {
+    title: blog?.title ? `${blog.title} — Dev Mohan` : "Blog — Dev Mohan",
+    description: blog?.summary || "Developer blog by Mohan Sagar.",
+    alternates: { canonical: `${BLOG_BASE}/${slug}` },
+    openGraph: {
+      title: blog?.title,
+      description: blog?.summary,
+      url: `${BLOG_BASE}/${slug}`,
+      type: "article",
+    },
+  };
+}
 
 export default async function BlogDetails(context) {
   const { slug } = await context.params;

--- a/src/app/blogs/page.js
+++ b/src/app/blogs/page.js
@@ -6,6 +6,9 @@ export const metadata = {
   title: "Blog - Dev Mohan",
   description:
     "Developer blog on frontend, backend, cloud, AI, and engineering practices.",
+  alternates: {
+    canonical: process.env.NEXT_PUBLIC_BLOG_URL || "https://blog.devmohan.in",
+  },
 };
 
 export default function Blogs() {

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -1,28 +1,24 @@
 import getBlogs from "@/libs/getBlogs";
 
 const BASE = process.env.NEXT_PUBLIC_SITE_URL || "https://devmohan.in";
+// The blog lives on its own subdomain; posts are canonical there.
+const BLOG_BASE = process.env.NEXT_PUBLIC_BLOG_URL || "https://blog.devmohan.in";
 
 // App Router sitemap: emitted as /sitemap.xml at build. Lists every blog post
-// so each is crawlable independent of how the /blogs list page renders.
+// (on the blog subdomain) so each is crawlable independent of list-page rendering.
 export default function sitemap() {
   const blogs = getBlogs() || [];
 
   const posts = blogs.map((b) => ({
-    url: `${BASE}/blogs/${b.id}`,
+    url: `${BLOG_BASE}/${b.id}`,
     lastModified: new Date(b.dateRaw || b.date || Date.now()),
     changeFrequency: "monthly",
     priority: 0.7,
   }));
 
-  const staticRoutes = [
-    { path: "", priority: 1.0, changeFrequency: "weekly" },
-    { path: "/blogs", priority: 0.8, changeFrequency: "daily" },
-  ].map(({ path, priority, changeFrequency }) => ({
-    url: `${BASE}${path}`,
-    lastModified: new Date(),
-    changeFrequency,
-    priority,
-  }));
-
-  return [...staticRoutes, ...posts];
+  return [
+    { url: BASE, lastModified: new Date(), changeFrequency: "weekly", priority: 1.0 },
+    { url: `${BLOG_BASE}/`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
+    ...posts,
+  ];
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+
+// Serve the blog under blog.devmohan.in while the app itself keeps its /blogs
+// routes. On the blog host we rewrite short URLs onto /blogs; on the apex domain
+// we redirect /blogs traffic to the subdomain so there's one canonical home.
+const BLOG_HOST = "blog.devmohan.in";
+
+export function middleware(request) {
+  const host = (request.headers.get("host") || "").split(":")[0].toLowerCase();
+  const { pathname } = request.nextUrl;
+
+  if (host === BLOG_HOST) {
+    // Internal links (and the /blogs pages) already carry the /blogs prefix —
+    // serve them as-is so navigation inside the app keeps working.
+    if (pathname === "/blogs" || pathname.startsWith("/blogs/")) {
+      return NextResponse.next();
+    }
+    // Map the subdomain root + short post URLs onto the real /blogs routes:
+    //   blog.devmohan.in/          -> /blogs
+    //   blog.devmohan.in/<slug>    -> /blogs/<slug>
+    const url = request.nextUrl.clone();
+    url.pathname = pathname === "/" ? "/blogs" : `/blogs${pathname}`;
+    return NextResponse.rewrite(url);
+  }
+
+  // On the apex/www domain, send blog traffic to the subdomain (SEO consolidation):
+  //   devmohan.in/blogs          -> https://blog.devmohan.in/
+  //   devmohan.in/blogs/<slug>   -> https://blog.devmohan.in/<slug>
+  if (pathname === "/blogs" || pathname.startsWith("/blogs/")) {
+    const url = request.nextUrl.clone();
+    url.protocol = "https:";
+    url.host = BLOG_HOST;
+    url.port = "";
+    url.pathname = pathname.replace(/^\/blogs/, "") || "/";
+    return NextResponse.redirect(url, 308);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  // Run on everything except Next internals, API routes, and static files
+  // (anything with a file extension, e.g. .xml/.txt/.png/.ico).
+  matcher: ["/((?!_next/|api/|.*\\.[^/]+$).*)"],
+};


### PR DESCRIPTION
Activates the blog subdomain. Middleware: on blog.devmohan.in rewrite / -> /blogs and /<slug> -> /blogs/<slug>; on the apex domain 308-redirect /blogs and /blogs/<slug> to the subdomain. Sitemap + per-post canonical + OG url now use blog.devmohan.in. Domain is already added + SSL-valid in Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)