### PR TITLE
Scroll to URL hash on load (fixes blog Contact -> devmohan.in/#contact)

### DIFF
--- a/src/components/shared/wrappers/PageWrapper.js
+++ b/src/components/shared/wrappers/PageWrapper.js
@@ -14,6 +14,7 @@ import useSticky from "@/hooks/useSticky";
 import animateInvertText from "@/libs/animateInvertText";
 import animateSplitText from "@/libs/animateSplitText ";
 import controlVanillaTilt from "@/libs/controlVanillaTilt";
+import scrollToHash from "@/libs/scrollToHash";
 import smoothScroll from "@/libs/smoothScroll";
 import tjTitleAnim from "@/libs/tjTitleAnim";
 import { useEffect } from "react";
@@ -39,6 +40,11 @@ const PageWrapper = ({
 		animateSplitText();
 		animateInvertText();
 		tjTitleAnim();
+		// Sections render client-side, so a #hash present on load (e.g. arriving
+		// at /#contact from the blog) has no target when the browser's native
+		// hash-scroll fires. Scroll to it ourselves once it mounts.
+		const cancelHashScroll = scrollToHash(window.location.hash);
+		return () => cancelHashScroll && cancelHashScroll();
 	}, []);
 	return (
 		<div>

--- a/src/libs/scrollToHash.js
+++ b/src/libs/scrollToHash.js
@@ -1,0 +1,55 @@
+// Scroll to the element named by a URL hash once it actually exists.
+//
+// The home page renders its sections client-side (content loads async), so when
+// the page is opened directly at a hash — e.g. arriving at devmohan.in/#contact
+// from the blog's Contact link — the browser's native hash-scroll fires before
+// the target section has mounted and does nothing. smoothScroll() only handles
+// clicks on same-page `#` links, not a hash present on load. This polls for the
+// target and scrolls to it as soon as it appears, then re-scrolls once after a
+// short settle to correct for layout shift from late-loading images above it.
+//
+// Returns a cancel function (clears any pending timers), or undefined when there
+// is nothing to do. Bounded by `attempts` so it never polls forever.
+const scrollToHash = (hash, { attempts = 40, interval = 100, settle = 450 } = {}) => {
+  if (typeof document === "undefined") return;
+  const raw = String(hash || "").replace(/^#/, "");
+  if (!raw) return;
+
+  let id;
+  try {
+    id = decodeURIComponent(raw);
+  } catch {
+    id = raw;
+  }
+
+  let pollTimer = null;
+  let settleTimer = null;
+  const cancel = () => {
+    if (pollTimer !== null) clearInterval(pollTimer);
+    if (settleTimer !== null) clearTimeout(settleTimer);
+  };
+
+  const scroll = () => {
+    const el = document.getElementById(id);
+    if (!el) return false;
+    el.scrollIntoView({ behavior: "smooth" });
+    // Re-align after content/images above settle the layout.
+    settleTimer = setTimeout(() => el.scrollIntoView({ behavior: "smooth" }), settle);
+    return true;
+  };
+
+  if (scroll()) return cancel;
+
+  let tries = 0;
+  pollTimer = setInterval(() => {
+    tries += 1;
+    if (scroll() || tries >= attempts) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }, interval);
+
+  return cancel;
+};
+
+export default scrollToHash;


### PR DESCRIPTION
### Symptom
On `blog.devmohan.in`, clicking **Contact** correctly redirects to `devmohan.in/#contact`, but the page lands at the top instead of scrolling to the Contact section.

### Root cause (systematic-debugging)
- The home page renders its sections **client-side** — `id="contact"` is **not in the initial HTML** (verified against the live SSR response). It mounts only after JS/content loads.
- The browser's **native hash-scroll** fires on initial load, finds no `#contact` element yet, and does nothing.
- `smoothScroll()` only binds `click` handlers to `a[href^="#"]` (same-page links) — it never handles a hash present in the URL on load, and doesn't even match `/#contact` links.

Net: any external arrival at `devmohan.in/#section` fails to scroll. The new blog Contact link just exposed it.

### Fix
New `src/libs/scrollToHash.js`: polls for the hash target, scrolls to it as soon as it mounts, and re-scrolls once after a short settle (layout shift from late-loading images above it). Bounded by max attempts so it never polls forever. Wired into `PageWrapper`'s mount effect, with cleanup.

Fixes the reported case and every other "open `devmohan.in/#x` directly" case.

### Tests
Added a standalone node test (mocked DOM + fake timers) covering: scrolls when the target mounts async, no-ops without a hash, and stops after max attempts. 3/3 pass. Production build passes (266/266).

🤖 Generated with [Claude Code](https://claude.com/claude-code)