### PR TITLE
Read content from admin.devmohan.in (prep portfolio-data private)

### DIFF
--- a/src/libs/contentMapping.js
+++ b/src/libs/contentMapping.js
@@ -1,6 +1,9 @@
 // Pure canonical→presentational mapping. No JSON imports and no Next.js
 // dependencies here: plain Node must be able to import this file for tests.
-export const RAW_BASE = "https://raw.githubusercontent.com/mohansagark/portfolio-data/main";
+// Content + images are served publicly by the portfolio-data Vercel deploy
+// (admin.devmohan.in), independent of the GitHub repo's visibility. Using it
+// instead of raw.githubusercontent lets portfolio-data be a private repo.
+export const RAW_BASE = "https://admin.devmohan.in";
 // Uploaded files (e.g. the resume PDF) are served by the admin site's Vercel
 // deployment, which serves the portfolio-data repo statically with proper
 // content types (GitHub raw would force a download).


### PR DESCRIPTION
Phase 3 step 1. Point `RAW_BASE` at `https://admin.devmohan.in` (which serves `/data` + `/images` publicly via its own Vercel deploy, regardless of repo visibility) instead of `raw.githubusercontent.com`. This lets `portfolio-data` be flipped to **private** without breaking the live portfolio. Repo visibility change happens AFTER this deploys and is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)