### PR TITLE
fix(testimonials): show all testimonials, not just the first 5

### DIFF
--- a/src/components/sections/testimonials/Testimonials1.js
+++ b/src/components/sections/testimonials/Testimonials1.js
@@ -6,7 +6,7 @@ import { Autoplay, Pagination } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 
 const Testimonials1 = () => {
-  const recommendations = getRecommendations()?.slice(0, 5);
+  const recommendations = getRecommendations();
   return (
     <section id="testimonials">
       <div className="bg-cream-light-color dark:bg-black-color py-60px md:py-20 lg:py-30">


### PR DESCRIPTION
## Problem
Newly added testimonials (Rahil, Bhuvanesh, Sukhdev) were not visible on `devmohan.in`, despite being present in the CMS, in the `portfolio-data` repo, and served correctly by `admin.devmohan.in`.

## Root cause
`src/components/sections/testimonials/Testimonials1.js` — the carousel the live homepage renders — capped the list:

```js
const recommendations = getRecommendations()?.slice(0, 5);
```

The data pipeline was healthy end-to-end; the 3 new entries are items #6–#8 and were sliced off before rendering. Next.js still serialized the full data into the page payload, which is why the names appeared in the HTML source but not on screen.

## Fix
Remove the `.slice(0, 5)` cap. The Swiper carousel already paginates and autoplays, so it presents the full set.

```diff
-  const recommendations = getRecommendations()?.slice(0, 5);
+  const recommendations = getRecommendations();
```

## Verification
- `admin.devmohan.in/data/testimonials.json` serves all 8 items (avatars HTTP 200)
- Repo source == host (byte-identical)
- After this change the carousel iterates the full array

🤖 Generated with [Claude Code](https://claude.com/claude-code)