### PR TITLE
fix: show full blog title in breadcrumbs

### DIFF
--- a/src/components/sections/heros/HeroBreadcarumb.js
+++ b/src/components/sections/heros/HeroBreadcarumb.js
@@ -1,5 +1,4 @@
 "use client";
-import sliceText from "@/libs/sliceText";
 import useHomeLink from "@/hooks/useHomeLink";
 import Link from "next/link";
 
@@ -49,8 +48,8 @@ const HeroBreadcarumb = ({ title, text, actualItem, path }) => {
                 </p>
               </li>
               <li className="nav_item group relative">
-                <p className="font-medium text-white-color capitalize relative flex items-center gap-10px ">
-                  {sliceText(text, 23, true)}
+                <p className="font-medium text-white-color capitalize relative flex items-center gap-10px text-center max-w-4xl">
+                  {text}
                 </p>
               </li>
             </ul>


### PR DESCRIPTION
## Summary
- Blog post breadcrumbs no longer truncate the current page title with `sliceText(..., 23)`.
- Full title is shown; crumb can wrap centered within a sane max width.

## Test plan
- [ ] Open a long-title blog post on `blog.devmohan.in`
- [ ] Confirm breadcrumb shows the complete title (no `...`)
- [ ] Confirm wrapping looks fine on mobile


Made with [Cursor](https://cursor.com)