### PR TITLE
fix: blog UX and SEO backlog (#26)

### DIFF
--- a/public/fakedata/socials.json
+++ b/public/fakedata/socials.json
@@ -18,5 +18,10 @@
     "id": "github",
     "iconName": "fa-brands fa-github",
     "path": "https://github.com/mohansagark"
+  },
+  {
+    "id": "medium",
+    "iconName": "fa-brands fa-medium",
+    "path": "https://mohansagark.medium.com/"
   }
 ]

--- a/src/app/blogs/[slug]/page.js
+++ b/src/app/blogs/[slug]/page.js
@@ -1,5 +1,6 @@
 import BlogDetailsMain from "@/components/layout/main/BlogDetailsMain";
 import PageWrapper from "@/components/shared/wrappers/PageWrapper";
+import { buildBlogJsonLd } from "@/libs/blogJsonLd";
 import getBlogs from "@/libs/getBlogs";
 import { notFound } from "next/navigation";
 
@@ -45,8 +46,19 @@ export default async function BlogDetails(context) {
     notFound();
   }
 
+  const jsonLd = buildBlogJsonLd(isExistBlog, {
+    blogBase: BLOG_BASE,
+    slug,
+  });
+
   return (
     <PageWrapper isInnerPage={true}>
+      {jsonLd ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      ) : null}
       <BlogDetailsMain blog={isExistBlog} />
     </PageWrapper>
   );

--- a/src/components/layout/footer/Footer.js
+++ b/src/components/layout/footer/Footer.js
@@ -75,7 +75,7 @@ const Footer = () => {
                   : "text-gray-color"
               } whitespace-nowrap text-sm md:text-base mt-5`}
             >
-              © 2025 All rights reserved by{" "}
+              © {new Date().getFullYear()} All rights reserved by{" "}
               <Link
                 href={homeLink("/")}
                 className={`${

--- a/src/components/layout/footer/Footer2.js
+++ b/src/components/layout/footer/Footer2.js
@@ -50,7 +50,9 @@ const Footer2 = () => {
             <ul className="flex justify-center xl:-mx-10px 2xl:mx-0 items-center flex-wrap gap-10px md:gap-0  ">
               <li className=" group md:border-r md:border-border-color dark:md:border-white-color-3 last:border-0">
                 <Link
-                  href="https://www.facebook.com"
+                  href="https://www.facebook.com/mohansagarkillamsetty"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className=" flex justify-center items-center w-160px sm:w-170px h-auto  md:h-160px lg:w-230px lg:h-210px xl:w-278px xl:h-238px p-10px relative text-base sm:text-lg xl:text-xl font-medium text-seondary-color dark:text-white-color tracking-normal xl:tracking-[0.02em] leading-1"
                 >
                   <span className=" transition-all duration-700 ease-in-out opacity-100 visible group-hover:invisible group-hover:opacity-0  group-hover:-translate-y-full inline-block">
@@ -63,7 +65,9 @@ const Footer2 = () => {
               </li>
               <li className=" group md:border-r md:border-border-color dark:md:border-white-color-3 last:border-0">
                 <Link
-                  href="https://www.instagram.com"
+                  href="https://www.instagram.com/mohansagark"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className=" flex justify-center items-center w-160px sm:w-170px h-auto  md:h-160px lg:w-230px lg:h-210px xl:w-278px xl:h-238px p-10px relative text-base sm:text-lg xl:text-xl font-medium text-seondary-color dark:text-white-color tracking-normal xl:tracking-[0.02em] leading-1"
                 >
                   <span className=" transition-all duration-700 ease-in-out opacity-100 visible group-hover:invisible group-hover:opacity-0  group-hover:-translate-y-full inline-block">
@@ -76,20 +80,24 @@ const Footer2 = () => {
               </li>
               <li className=" group md:border-r md:border-border-color dark:md:border-white-color-3 last:border-0">
                 <Link
-                  href="https://x.com"
+                  href="https://mohansagark.medium.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className=" flex justify-center items-center w-160px sm:w-170px h-auto  md:h-160px lg:w-230px lg:h-210px xl:w-278px xl:h-238px p-10px relative text-base sm:text-lg xl:text-xl font-medium text-seondary-color dark:text-white-color tracking-normal xl:tracking-[0.02em] leading-1"
                 >
                   <span className=" transition-all duration-700 ease-in-out opacity-100 visible group-hover:invisible group-hover:opacity-0  group-hover:-translate-y-full inline-block">
-                    My Twitter
+                    My Medium
                   </span>
                   <span className="text-seondary-color  border border-seondary-color  dark:text-white-color dark:border-white-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden z-0 absolute transition-all duration-700  ease-in-out invisible opacity-0 group-hover:opacity-100 group-hover:visible left-1/2  -translate-x-1/2 translate-y-full group-hover:translate-y-0 text-base leading-1 font-normal ">
-                    <i className="fab fa-twitter"></i>
+                    <i className="fa-brands fa-medium"></i>
                   </span>
                 </Link>
               </li>
               <li className=" group md:border-r md:border-border-color dark:md:border-white-color-3 last:border-0">
                 <Link
-                  href="https://www.linkedin.com"
+                  href="https://www.linkedin.com/in/mohansagark/"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className=" flex justify-center items-center w-160px sm:w-170px h-auto  md:h-160px lg:w-230px lg:h-210px xl:w-278px xl:h-238px p-10px relative text-base sm:text-lg xl:text-xl font-medium text-seondary-color dark:text-white-color tracking-normal xl:tracking-[0.02em] leading-1"
                 >
                   <span className=" transition-all duration-700 ease-in-out opacity-100 visible group-hover:invisible group-hover:opacity-0  group-hover:-translate-y-full inline-block">
@@ -106,7 +114,7 @@ const Footer2 = () => {
 
         <div className="flex flex-col items-center py-25px md:py-35px border-t border-border-color dark:border-white-color-3 px-15px">
           <div className="copyright text-gray-color dark:text-body-color whitespace-nowrap text-sm md:text-base ">
-            © 2025 All rights reserved by
+            © {new Date().getFullYear()} All rights reserved by
             <Link
               href="/"
               className="text-primary-color-light dark:text-white-color hover:text-primary-color  dark:hover:text-primary-color "

--- a/src/components/layout/footer/Footer3.js
+++ b/src/components/layout/footer/Footer3.js
@@ -151,16 +151,18 @@ const Footer3 = () => {
                 </li>
                 <li className="nav_item group relative ">
                   <Link
-                    href="#"
+                    href="https://mohansagark.medium.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-size-15 font-normal text-seondary-color dark:text-white-color hover:text-primary-color dark:hover:text-primary-color capitalize flex gap-2 items-center "
                   >
                     <span
                       className="text-primary-color group-hover:text-body-color dark:text-white-color
                   text-size-13 border border-primary-color dark:border-border-color-3 dark:group-hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color group-hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
                     >
-                      <i className="fa-brands fa-twitter"></i>
+                      <i className="fa-brands fa-medium"></i>
                     </span>{" "}
-                    Twitter
+                    Medium
                   </Link>
                 </li>
               </ul>
@@ -215,7 +217,7 @@ const Footer3 = () => {
           </div>
           <div className="flex flex-col items-center py-25px md:py-35px  px-15px">
             <div className="copyright text-gray-color dark:text-body-color whitespace-nowrap text-sm md:text-base ">
-              © 2025 All rights reserved by
+              © {new Date().getFullYear()} All rights reserved by
               <Link
                 href="/"
                 className="text-primary-color-light dark:text-white-color hover:text-primary-color  dark:hover:text-primary-color "

--- a/src/components/layout/main/BlogDetailsMain.js
+++ b/src/components/layout/main/BlogDetailsMain.js
@@ -37,6 +37,7 @@ const BlogDetailsMain = ({ blog: passedBlog }) => {
         text={title ? title : "Blog Details"}
         actualItem={"Blogs"}
         path={"/blogs"}
+        titleAs="p"
       />
       <BlogDetailsPrimary
         prevId={prevBlog?.id}

--- a/src/components/sections/blog-details/BlogDetailsPrimary.js
+++ b/src/components/sections/blog-details/BlogDetailsPrimary.js
@@ -1,5 +1,11 @@
+import BlogTableOfContents from "@/components/shared/blogs/BlogTableOfContents";
+import AuthorDisplay from "@/components/shared/AuthorDisplay";
 import BlogSidebar from "@/components/shared/sidebar/BlogSidebar";
 import countCommentLength from "@/libs/countCommentLength";
+import {
+  extractHeadings,
+  wordCountFromHtml,
+} from "@/libs/extractHeadings";
 import makePath from "@/libs/makePath";
 import sliceText from "@/libs/sliceText";
 import Link from "next/link";
@@ -29,6 +35,12 @@ const BlogDetailsPrimary = ({
   const { title: prevBlogTitle } = pervblog || {};
   const { title: nextBlogTitle } = nextblog || {};
 
+  const rawHtml = blog?.html || "";
+  const { headings, htmlWithIds } = extractHeadings(rawHtml);
+  const h2Count = headings.filter((h) => h.level === 2).length;
+  const words = wordCountFromHtml(rawHtml);
+  const showToc = h2Count >= 4 || words >= 1500;
+
   return (
     <section id="blogs">
       <div className="py-60px md:py-20 lg:py-100px xl:py-30 dark:bg-black-color">
@@ -55,18 +67,18 @@ const BlogDetailsPrimary = ({
                           key={1000 + idx}
                           className="text-primary-color dark:text-white-color"
                         >
-                          <i
-                            className={`${iconName} mr-1 text-primary-color transition-all duration-500`}
-                          ></i>{" "}
                           {path ? (
-                            <Link
-                              href={`/blogs?author=${makePath(author)}`}
-                              className="text-primary-color dark:text-white-color hover:text-primary-color transition-all duration-500 capitalize"
-                            >
-                              By {name}
-                            </Link>
+                            <AuthorDisplay
+                              author={author || name}
+                              className="text-primary-color dark:text-white-color"
+                            />
                           ) : (
-                            name
+                            <>
+                              <i
+                                className={`${iconName} mr-1 text-primary-color transition-all duration-500`}
+                              ></i>{" "}
+                              {name}
+                            </>
                           )}
                         </li>
                       ))
@@ -84,14 +96,14 @@ const BlogDetailsPrimary = ({
                   )}
                 </ul>
 
-                {/* title */}
+                {/* sole H1 for the post page */}
                 <h1 className="text-primary-color dark:text-white-color capitalize text-size-28 md:text-4xl font-bold leading-tight mb-4">
                   {title}
                 </h1>
 
                 {/* lead / summary */}
                 {desc ? (
-                  <p className="text-primary-color-light dark:text-white-color text-lg leading-relaxed mb-6">
+                  <p className="text-primary-color-light dark:text-white-color text-lg leading-relaxed mb-6 max-w-[65ch]">
                     {desc}
                   </p>
                 ) : null}
@@ -110,15 +122,17 @@ const BlogDetailsPrimary = ({
                   </div>
                 ) : null}
 
-                {/* post body: precompiled, sanitized HTML from portfolio-blog */}
+                {showToc ? <BlogTableOfContents headings={headings} /> : null}
+
+                {/* post body: ~18px / 1.5 lh / ~65ch measure */}
                 <div
-                  className="prose prose-lg dark:prose-invert max-w-none break-words prose-headings:text-primary-color-light dark:prose-headings:text-white-color prose-p:text-primary-color-light dark:prose-p:text-white-color prose-strong:text-primary-color-light dark:prose-strong:text-white-color prose-a:text-primary-color prose-li:text-primary-color-light dark:prose-li:text-white-color prose-pre:overflow-x-auto prose-img:rounded-lg"
-                  dangerouslySetInnerHTML={{ __html: blog?.html || "" }}
+                  className="prose prose-lg dark:prose-invert max-w-[65ch] text-lg leading-normal break-words prose-p:leading-[1.5] prose-li:leading-[1.5] prose-headings:text-primary-color-light dark:prose-headings:text-white-color prose-p:text-primary-color-light dark:prose-p:text-white-color prose-strong:text-primary-color-light dark:prose-strong:text-white-color prose-a:text-primary-color prose-li:text-primary-color-light dark:prose-li:text-white-color prose-pre:overflow-x-auto prose-img:rounded-lg"
+                  dangerouslySetInnerHTML={{ __html: htmlWithIds }}
                 />
 
                 {/* key takeaways (only when present) */}
                 {keyTakeaways?.length ? (
-                  <div className="mt-30px">
+                  <div className="mt-30px max-w-[65ch]">
                     <h2 className="text-primary-color-light dark:text-white-color text-2xl font-bold mb-4">
                       Key Takeaways
                     </h2>
@@ -129,7 +143,7 @@ const BlogDetailsPrimary = ({
                           className="pl-25px mb-10px relative before:content-['\f058'] before:font-fontawesome before:absolute before:left-0 before:top-0 before:text-primary-color before:font-bold"
                         >
                           <span
-                            className="text-primary-color-light dark:text-white-color"
+                            className="text-primary-color-light dark:text-white-color text-lg leading-[1.5]"
                             dangerouslySetInnerHTML={{ __html: takeaway }}
                           />
                         </li>
@@ -173,6 +187,9 @@ const BlogDetailsPrimary = ({
                     <li>
                       <Link
                         href="https://www.linkedin.com/in/mohansagark/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="LinkedIn"
                         className="text-primary-color dark:text-white-color border border-primary-color hover:bg-primary-color w-10 h-10 rounded-full flex items-center justify-center overflow-hidden"
                       >
                         <i className="fa-brands fa-linkedin-in"></i>
@@ -181,6 +198,9 @@ const BlogDetailsPrimary = ({
                     <li>
                       <Link
                         href="https://github.com/mohansagark"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="GitHub"
                         className="text-primary-color dark:text-white-color border border-primary-color hover:bg-primary-color w-10 h-10 rounded-full flex items-center justify-center overflow-hidden"
                       >
                         <i className="fa-brands fa-github"></i>
@@ -188,10 +208,13 @@ const BlogDetailsPrimary = ({
                     </li>
                     <li>
                       <Link
-                        href="https://x.com"
+                        href="https://mohansagark.medium.com/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Medium"
                         className="text-primary-color dark:text-white-color border border-primary-color hover:bg-primary-color w-10 h-10 rounded-full flex items-center justify-center overflow-hidden"
                       >
-                        <i className="fa-brands fa-x-twitter"></i>
+                        <i className="fa-brands fa-medium"></i>
                       </Link>
                     </li>
                   </ul>

--- a/src/components/sections/heros/HeroBreadcarumb.js
+++ b/src/components/sections/heros/HeroBreadcarumb.js
@@ -2,16 +2,24 @@
 import useHomeLink from "@/hooks/useHomeLink";
 import Link from "next/link";
 
-const HeroBreadcarumb = ({ title, text, actualItem, path }) => {
+const HeroBreadcarumb = ({
+  title,
+  text,
+  actualItem,
+  path,
+  /** Use a non-heading element on blog detail pages so the article keeps the sole H1. */
+  titleAs = "h1",
+}) => {
   const homeLink = useHomeLink();
+  const TitleTag = titleAs === "h1" ? "h1" : "p";
   return (
     <section>
       <div className="hero-breadcurmb pt-150px md:pt-40 lg:pt-200px pb-50px md:pb-60px lg:b-100px bg-[url('/img/breadcrumb/breadcrumb-bg.jpg')] bg-cover bg-center bg-no-repeat relative z-1 after:absolute after:top-0 after:left-0 after:w-full after:h-full after:bg-primary-color-light after:-z-1 after:opacity-70">
         <div className="container">
           <div className="flex flex-col items-center">
-            <h1 className="text-size-35 md:text-size-40 lg:text-size-50 font-bold text-white-color mb-15px capitalize text-center">
+            <TitleTag className="text-size-35 md:text-size-40 lg:text-size-50 font-bold text-white-color mb-15px capitalize text-center">
               {title}
-            </h1>
+            </TitleTag>
             {/* <!-- breadcrumbs --> */}
             <ul className="nav flex flex-wrap justify-center items-center gap-x-3">
               <li className="nav_item group relative">

--- a/src/components/shared/AuthorDisplay.js
+++ b/src/components/shared/AuthorDisplay.js
@@ -61,7 +61,7 @@ const AuthorDisplay = ({
         aria-expanded={open}
         aria-controls={panelId}
         onFocus={() => setOpen(true)}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen(true)}
       >
         {author}
       </button>

--- a/src/components/shared/AuthorDisplay.js
+++ b/src/components/shared/AuthorDisplay.js
@@ -1,17 +1,102 @@
-import React from "react";
+"use client";
 
-const AuthorDisplay = ({ author, className = "" }) => {
+import Link from "next/link";
+import React, { useEffect, useId, useRef, useState } from "react";
+
+const LINKEDIN_URL = "https://www.linkedin.com/in/mohansagark/";
+const LINKEDIN_LABEL = "Mohan Sagar Killamsetty";
+const LINKEDIN_HEADLINE = "Software Engineer · Dev Mohan";
+
+const AuthorDisplay = ({
+  author,
+  className = "",
+  showBy = true,
+  linkedInUrl = LINKEDIN_URL,
+}) => {
   const isBot = author === "Agent Bot";
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef(null);
+  const panelId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    const onPointer = (e) => {
+      if (rootRef.current && !rootRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("pointerdown", onPointer);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("pointerdown", onPointer);
+    };
+  }, [open]);
+
+  if (isBot) {
+    return (
+      <span className={`inline-flex items-center gap-1 ${className}`}>
+        {showBy ? <span>By</span> : null}
+        <i className="fa-solid fa-robot" title="AI Bot"></i>
+        <span>{author}</span>
+      </span>
+    );
+  }
 
   return (
-    <span className={`inline-flex items-center gap-1 ${className}`}>
-      <span>By</span>
-      {isBot ? (
-        <i className="fa-solid fa-robot" title="AI Bot"></i>
-      ) : (
-        <i className="fa-solid fa-user" title="Human Author"></i>
-      )}
-      <span>{author}</span>
+    <span
+      ref={rootRef}
+      className={`relative inline-flex items-center gap-1 ${className}`}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      {showBy ? <span>By</span> : null}
+      <i className="fa-solid fa-user" title="Human Author" aria-hidden="true"></i>
+      <button
+        type="button"
+        className="text-inherit capitalize hover:text-primary-color transition-colors duration-300 underline-offset-2 hover:underline bg-transparent border-0 p-0 cursor-pointer font-inherit"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onFocus={() => setOpen(true)}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {author}
+      </button>
+
+      {open ? (
+        <div
+          id={panelId}
+          role="dialog"
+          aria-label={`${author} LinkedIn profile`}
+          className="absolute left-0 top-full z-50 mt-2 w-72 rounded-lg border border-border-color dark:border-gray-color-3 bg-white dark:bg-primary-color-light p-4 shadow-lg text-left normal-case"
+        >
+          <div className="flex items-start gap-3">
+            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[#0A66C2] text-white text-lg">
+              <i className="fa-brands fa-linkedin-in" aria-hidden="true"></i>
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-bold text-primary-color-light dark:text-white-color leading-snug">
+                {LINKEDIN_LABEL}
+              </p>
+              <p className="text-xs text-body-color dark:text-gray-color mt-0.5 leading-snug">
+                {LINKEDIN_HEADLINE}
+              </p>
+              <Link
+                href={linkedInUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-[#0A66C2] hover:underline"
+              >
+                View LinkedIn profile
+                <i className="fa-solid fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </span>
   );
 };

--- a/src/components/shared/blogs/BlogSingle.js
+++ b/src/components/shared/blogs/BlogSingle.js
@@ -53,18 +53,18 @@ const BlogSingle = ({ blog }) => {
                           key={1000 + idx}
                           className="text-primary-color dark:text-white-color "
                         >
-                          <i
-                            className={`${iconName} mr-1 text-primary-color transition-all duration-500`}
-                          ></i>{" "}
                           {path ? (
-                            <Link
-                              href={`/blogs?author=${makePath(author)}`}
-                              className="text-primary-color dark:text-white-color hover:text-primary-color transition-all duration-500 capitalize"
-                            >
-                              By {name}
-                            </Link>
+                            <AuthorDisplay
+                              author={author || name}
+                              className="text-primary-color dark:text-white-color"
+                            />
                           ) : (
-                            name
+                            <>
+                              <i
+                                className={`${iconName} mr-1 text-primary-color transition-all duration-500`}
+                              ></i>{" "}
+                              {name}
+                            </>
                           )}
                         </li>
                       ))
@@ -93,7 +93,7 @@ const BlogSingle = ({ blog }) => {
                 <p className="text-primary-color-light dark:text-white-color mb-5 md:mb-30px">
                   {desc}
                 </p>
-                <div>
+                <div className="flex justify-end">
                   <Link
                     href={`/blogs/${id}`}
                     className="text-size-15 font-bold text-white-color capitalize py-17px px-35px bg-200 bg-gradient-secondary hover:bg-[-100%] rounded-full leading-1 transition-all duration-300"

--- a/src/components/shared/blogs/BlogTableOfContents.js
+++ b/src/components/shared/blogs/BlogTableOfContents.js
@@ -1,0 +1,36 @@
+import React from "react";
+
+/**
+ * In-page TOC for long posts. Shown when there are enough H2s (or caller opts in).
+ */
+const BlogTableOfContents = ({ headings = [] }) => {
+  if (!headings?.length) return null;
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      className="mb-8 rounded-lg border border-border-color dark:border-gray-color-3 bg-cream-light-color/60 dark:bg-primary-color-light/60 px-5 py-5"
+    >
+      <h2 className="text-primary-color-light dark:text-white-color text-lg font-bold mb-3">
+        On this page
+      </h2>
+      <ol className="space-y-2 list-none m-0 p-0">
+        {headings.map(({ id, text, level }) => (
+          <li
+            key={id}
+            className={level === 3 ? "pl-4" : ""}
+          >
+            <a
+              href={`#${id}`}
+              className="text-primary-color-light dark:text-white-color hover:text-primary-color dark:hover:text-primary-color text-[0.95rem] leading-snug transition-colors duration-300"
+            >
+              {text}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};
+
+export default BlogTableOfContents;

--- a/src/components/shared/others/LeoLoader.js
+++ b/src/components/shared/others/LeoLoader.js
@@ -17,6 +17,7 @@ export default function LeoLoader({ workerUrl }) {
         consentText: "I agree to share my info so I can be followed up with.",
         privacyPolicyUrl: null,
       },
+      // Chat-first: TTS stays off until the visitor unmutes the sound control.
       voice: { enabled: true, speakByDefault: false },
     };
     const existing = document.querySelector("script[data-ai-voice-bot]");

--- a/src/components/shared/others/Paginations.js
+++ b/src/components/shared/others/Paginations.js
@@ -39,10 +39,10 @@ const Paginations = ({ paginationDetails }) => {
   return (
     <nav
       aria-label="Blog pagination"
-      className="wow fadeInUp"
+      className="wow fadeInUp w-full"
       data-wow-delay=".3s"
     >
-      <ul className="paginations flex flex-nowrap justify-center items-center gap-2 sm:gap-3">
+      <ul className="paginations flex flex-nowrap justify-between sm:justify-between items-center gap-2 sm:gap-3 w-full">
         {/* previous */}
         <li>
           <Link

--- a/src/components/shared/sidebar/widgets/BlogCategoriesWidget.js
+++ b/src/components/shared/sidebar/widgets/BlogCategoriesWidget.js
@@ -1,13 +1,9 @@
-import countDataLength from "@/libs/countDataLength";
-import filterItems from "@/libs/filterItems";
 import getBlogCategories from "@/libs/getBlogCategories";
-import getBlogs from "@/libs/getBlogs";
 import makePath from "@/libs/makePath";
 import Link from "next/link";
 
 const BlogCategoriesWidget = () => {
   const categories = getBlogCategories();
-  const blogs = getBlogs();
   return (
     <div
       className="px-15px md:px-25px py-30px bg-cream-light-color dark:bg-primary-color-light rounded-lg wow fadeInUp"
@@ -16,14 +12,13 @@ const BlogCategoriesWidget = () => {
       <h3 className="mb-25px text-primary-color dark:text-white-color uppercase relative z-0 text-size-lg md:text-xl font-bold">
         Categories
       </h3>
-      {/* <!-- list --> */}
 
       <div className="max-h-60 overflow-y-auto scrollbar-thin scrollbar-thumb-primary-color scrollbar-track-gray-100 dark:scrollbar-track-gray-800">
         <ul>
           {categories?.length
-            ? categories?.map((category, idx) => (
+            ? categories.map(({ category, count }, idx) => (
                 <li
-                  key={idx}
+                  key={category}
                   className="flex items-center justify-between gap-x-5 font-medium"
                 >
                   <Link
@@ -38,13 +33,7 @@ const BlogCategoriesWidget = () => {
                   >
                     {category}
                   </Link>
-                  <span className="text-primary-color">
-                    (
-                    {countDataLength(
-                      filterItems(blogs, "category", makePath(category))
-                    )}
-                    )
-                  </span>
+                  <span className="text-primary-color">({count})</span>
                 </li>
               ))
             : ""}

--- a/src/components/shared/socials/Socials2.js
+++ b/src/components/shared/socials/Socials2.js
@@ -1,40 +1,25 @@
+import getSocials from "@/libs/getSocials";
 import React from "react";
 
 const Socials2 = () => {
+  const socials = getSocials();
   return (
     <ul className="flex gap-x-5">
-      <li>
-        <a
-          href="https://www.facebook.com"
-          className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-        >
-          <i className="fab fa-facebook-f"></i>
-        </a>
-      </li>
-      <li>
-        <a
-          href="https://www.instagram.com"
-          className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-        >
-          <i className="fab fa-instagram"></i>
-        </a>
-      </li>
-      <li>
-        <a
-          href="https://www.basketball.com"
-          className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-        >
-          <i className="fa-light fa-basketball"></i>
-        </a>
-      </li>
-      <li>
-        <a
-          href="https://www.behance.com"
-          className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-        >
-          <i className="fab fa-behance"></i>
-        </a>
-      </li>
+      {socials?.length
+        ? socials.map(({ id, iconName, path }) => (
+            <li key={id}>
+              <a
+                href={path}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={id}
+                className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
+              >
+                <i className={iconName}></i>
+              </a>
+            </li>
+          ))
+        : null}
     </ul>
   );
 };

--- a/src/components/shared/socials/Socials3.js
+++ b/src/components/shared/socials/Socials3.js
@@ -1,41 +1,26 @@
+import getSocials from "@/libs/getSocials";
 import Link from "next/link";
 import React from "react";
 
 const Socials3 = () => {
+  const socials = getSocials();
   return (
     <ul className="flex gap-x-5 wow fadeInRight" data-wow-delay=".7s">
-      <li>
-        <Link
-          href="https://www.facebook.com"
-          className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-        >
-          <i className="fab fa-facebook-f"></i>
-        </Link>
-      </li>
-      <li>
-        <Link
-          href="https://www.instagram.com"
-          className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-        >
-          <i className="fab fa-instagram"></i>
-        </Link>
-      </li>
-      <li>
-        <Link
-          href="https://x.com"
-          className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-        >
-          <i className="fab fa-twitter"></i>
-        </Link>
-      </li>
-      <li>
-        <Link
-          href="https://www.linkedin.com"
-          className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-        >
-          <i className="fab fa-linkedin-in"></i>
-        </Link>
-      </li>
+      {socials?.length
+        ? socials.map(({ id, iconName, path }) => (
+            <li key={id}>
+              <Link
+                href={path}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={id}
+                className="text-primary-color hover:text-body-color border border-primary-color w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
+              >
+                <i className={iconName}></i>
+              </Link>
+            </li>
+          ))
+        : null}
     </ul>
   );
 };

--- a/src/components/shared/socials/Socials4.js
+++ b/src/components/shared/socials/Socials4.js
@@ -1,60 +1,34 @@
+import getSocials from "@/libs/getSocials";
+
 const Socials4 = ({ type }) => {
-	return (
-		<ul
-			className={`flex items-center gap-x-5 ${
-				type === 2 ? "justify-center mb-10 md:mb-50px" : " "
-			}`}
-		>
-			<li>
-				<a
-					href="https://www.facebook.com"
-					className={`text-primary-color hover:text-body-color border ${
-						type == 2
-							? "border-primary-color dark:border-seondary-color"
-							: "border-primary-color"
-					} w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full`}
-				>
-					<i className="fab fa-facebook-f"></i>
-				</a>
-			</li>
-			<li>
-				<a
-					href="https://www.linkedin.com"
-					className={`text-primary-color hover:text-body-color border ${
-						type == 2
-							? "border-primary-color dark:border-seondary-color"
-							: "border-primary-color"
-					} w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full`}
-				>
-					<i className="fa-brands fa-linkedin-in"></i>
-				</a>
-			</li>
-			<li>
-				<a
-					href="https://www.github.com"
-					className={`text-primary-color hover:text-body-color border ${
-						type == 2
-							? "border-primary-color dark:border-seondary-color"
-							: "border-primary-color"
-					} w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full`}
-				>
-					<i className="fa-brands fa-github"></i>
-				</a>
-			</li>
-			<li>
-				<a
-					href="https://www.basketball.com"
-					className={`text-primary-color hover:text-body-color border ${
-						type == 2
-							? "border-primary-color dark:border-seondary-color"
-							: "border-primary-color"
-					} w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full`}
-				>
-					<i className="fa-light fa-basketball"></i>
-				</a>
-			</li>
-		</ul>
-	);
+  const socials = getSocials();
+  return (
+    <ul
+      className={`flex items-center gap-x-5 ${
+        type === 2 ? "justify-center mb-10 md:mb-50px" : " "
+      }`}
+    >
+      {socials?.length
+        ? socials.map(({ id, iconName, path }) => (
+            <li key={id}>
+              <a
+                href={path}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={id}
+                className={`text-primary-color hover:text-body-color border ${
+                  type == 2
+                    ? "border-primary-color dark:border-seondary-color"
+                    : "border-primary-color"
+                } w-35px h-35px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full`}
+              >
+                <i className={iconName}></i>
+              </a>
+            </li>
+          ))
+        : null}
+    </ul>
+  );
 };
 
 export default Socials4;

--- a/src/components/shared/socials/Socials5.js
+++ b/src/components/shared/socials/Socials5.js
@@ -1,40 +1,26 @@
+import getSocials from "@/libs/getSocials";
+
 const Socials5 = () => {
-	return (
-		<ul className=" hidden xl:flex  gap-x-10px">
-			<li>
-				<a
-					href="https://www.facebook.com"
-					className="text-primary-color hover:text-body-color text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-				>
-					<i className="fab fa-facebook-f"></i>
-				</a>
-			</li>
-			<li>
-				<a
-					href="https://www.linkedin.com"
-					className="text-primary-color hover:text-body-color text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-				>
-					<i className="fa-brands fa-linkedin-in"></i>
-				</a>
-			</li>
-			<li>
-				<a
-					href="https://www.github.com"
-					className="text-primary-color hover:text-body-color text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-				>
-					<i className="fa-brands fa-github"></i>
-				</a>
-			</li>
-			<li>
-				<a
-					href="https://www.basketball.com"
-					className="text-primary-color hover:text-body-color text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-				>
-					<i className="fa-light fa-basketball"></i>
-				</a>
-			</li>
-		</ul>
-	);
+  const socials = getSocials();
+  return (
+    <ul className=" hidden xl:flex  gap-x-10px">
+      {socials?.length
+        ? socials.map(({ id, iconName, path }) => (
+            <li key={id}>
+              <a
+                href={path}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={id}
+                className="text-primary-color hover:text-body-color text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
+              >
+                <i className={iconName}></i>
+              </a>
+            </li>
+          ))
+        : null}
+    </ul>
+  );
 };
 
 export default Socials5;

--- a/src/components/shared/socials/Socials6.js
+++ b/src/components/shared/socials/Socials6.js
@@ -1,42 +1,27 @@
+import getSocials from "@/libs/getSocials";
 import Link from "next/link";
 
 const Socials6 = () => {
-	return (
-		<ul className=" hidden md:flex lg:hidden xl:flex  gap-x-10px">
-			<li>
-				<Link
-					href="https://www.facebook.com"
-					className="text-primary-color dark:text-white-color hover:text-body-color  text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-				>
-					<i className="fab fa-facebook-f"></i>
-				</Link>
-			</li>
-			<li>
-				<Link
-					href="https://www.linkedin.com"
-					className="text-primary-color dark:text-white-color hover:text-body-color  text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-				>
-					<i className="fa-brands fa-linkedin-in"></i>
-				</Link>
-			</li>
-			<li>
-				<Link
-					href="https://www.github.com"
-					className="text-primary-color dark:text-white-color hover:text-body-color  text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-				>
-					<i className="fa-brands fa-github"></i>
-				</Link>
-			</li>
-			<li>
-				<Link
-					href="https://www.basketball.com"
-					className="text-primary-color dark:text-white-color hover:text-body-color  text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
-				>
-					<i className="fa-light fa-basketball"></i>
-				</Link>
-			</li>
-		</ul>
-	);
+  const socials = getSocials();
+  return (
+    <ul className=" hidden md:flex lg:hidden xl:flex  gap-x-10px">
+      {socials?.length
+        ? socials.map(({ id, iconName, path }) => (
+            <li key={id}>
+              <Link
+                href={path}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={id}
+                className="text-primary-color dark:text-white-color hover:text-body-color  text-size-13 border border-primary-color dark:border-border-color-3 dark:hover:border-primary-color w-30px h-30px rounded-full flex items-center justify-center overflow-hidden relative z-0 after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-full after:h-full after:scale-0 after:bg-primary-color hover:after:scale-105 after:transition-all after:duration-300 after:z-[-1] after:rounded-full"
+              >
+                <i className={iconName}></i>
+              </Link>
+            </li>
+          ))
+        : null}
+    </ul>
+  );
 };
 
 export default Socials6;

--- a/src/libs/blogJsonLd.js
+++ b/src/libs/blogJsonLd.js
@@ -1,0 +1,69 @@
+import { extractFaqPairs } from "./extractHeadings";
+
+const LINKEDIN = "https://www.linkedin.com/in/mohansagark/";
+const SITE = "https://devmohan.in";
+
+/**
+ * Build Article + BreadcrumbList (+ FAQPage when FAQ exists) JSON-LD graphs.
+ */
+export function buildBlogJsonLd(blog, { blogBase, slug } = {}) {
+  if (!blog) return null;
+  const base = (blogBase || process.env.NEXT_PUBLIC_BLOG_URL || "https://blog.devmohan.in").replace(
+    /\/$/,
+    ""
+  );
+  const url = `${base}/${slug || blog.id}`;
+  const cover = blog.coverImage
+    ? blog.coverImage.startsWith("http")
+      ? blog.coverImage
+      : `${base}${blog.coverImage}`
+    : undefined;
+
+  const article = {
+    "@type": "Article",
+    headline: blog.title,
+    description: blog.summary || blog.desc || undefined,
+    datePublished: blog.dateRaw || undefined,
+    dateModified: blog.dateRaw || undefined,
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    author: {
+      "@type": "Person",
+      name: blog.author || "Mohan Sagar",
+      url: LINKEDIN,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Dev Mohan",
+      url: SITE,
+    },
+    ...(cover ? { image: [cover] } : {}),
+    ...(blog.tags?.length ? { keywords: blog.tags.join(", ") } : {}),
+  };
+
+  const breadcrumb = {
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: SITE },
+      { "@type": "ListItem", position: 2, name: "Blogs", item: `${SITE}/blogs` },
+      { "@type": "ListItem", position: 3, name: blog.title, item: url },
+    ],
+  };
+
+  const graph = [article, breadcrumb];
+  const faq = extractFaqPairs(blog.html || "");
+  if (faq.length) {
+    graph.push({
+      "@type": "FAQPage",
+      mainEntity: faq.map(({ question, answer }) => ({
+        "@type": "Question",
+        name: question,
+        acceptedAnswer: { "@type": "Answer", text: answer },
+      })),
+    });
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": graph,
+  };
+}

--- a/src/libs/contentMapping.js
+++ b/src/libs/contentMapping.js
@@ -163,6 +163,7 @@ const SOCIAL_ICONS = {
   instagram: "fa-brands fa-instagram",
   linkedin: "fa-brands fa-linkedin-in",
   github: "fa-brands fa-github",
+  medium: "fa-brands fa-medium",
 };
 
 export function mapSocials(socials) {

--- a/src/libs/extractHeadings.js
+++ b/src/libs/extractHeadings.js
@@ -1,0 +1,78 @@
+/**
+ * Pull H2/H3 headings from HTML for TOC / anchors.
+ * Adds id attributes when missing (returned as `htmlWithIds`).
+ */
+export function extractHeadings(html = "") {
+  if (!html) return { headings: [], htmlWithIds: html };
+
+  const used = new Set();
+  const slugify = (text) => {
+    let base = text
+      .toLowerCase()
+      .replace(/<[^>]+>/g, "")
+      .replace(/&[^;]+;/g, " ")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "")
+      .slice(0, 80);
+    if (!base) base = "section";
+    let id = base;
+    let n = 2;
+    while (used.has(id)) {
+      id = `${base}-${n++}`;
+    }
+    used.add(id);
+    return id;
+  };
+
+  const headings = [];
+  const htmlWithIds = html.replace(
+    /<h([23])(\s[^>]*)?>([\s\S]*?)<\/h\1>/gi,
+    (full, level, attrs = "", inner) => {
+      const text = inner.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+      if (!text) return full;
+      const existing = /\sid\s*=\s*["']([^"']+)["']/i.exec(attrs || "");
+      const id = existing ? existing[1] : slugify(text);
+      if (!existing) used.add(id);
+      headings.push({ level: Number(level), id, text });
+      if (existing) return full;
+      const nextAttrs = attrs ? `${attrs} id="${id}"` : ` id="${id}"`;
+      return `<h${level}${nextAttrs}>${inner}</h${level}>`;
+    }
+  );
+
+  return { headings, htmlWithIds };
+}
+
+/** Plain-text word count for TOC threshold. */
+export function wordCountFromHtml(html = "") {
+  const text = html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+  if (!text) return 0;
+  return text.split(" ").length;
+}
+
+/**
+ * Best-effort FAQ pairs from an FAQ section in HTML (for FAQPage JSON-LD).
+ */
+export function extractFaqPairs(html = "") {
+  if (!html || !/faq|frequently asked/i.test(html)) return [];
+
+  const sectionMatch =
+    html.match(
+      /<h2[^>]*>[\s\S]*?(?:faq|frequently asked)[\s\S]*?<\/h2>([\s\S]*?)(?=<h2[\s>]|$)/i
+    ) || [];
+  const section = sectionMatch[1] || html;
+  const pairs = [];
+
+  // Pattern: <h3>Question?</h3> followed by block(s) until next h3/h2
+  const re =
+    /<h3[^>]*>([\s\S]*?)<\/h3>\s*([\s\S]*?)(?=<h[23][\s>]|$)/gi;
+  let m;
+  while ((m = re.exec(section)) !== null) {
+    const question = m[1].replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+    const answer = m[2].replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+    if (question && answer && question.length < 300 && answer.length > 10) {
+      pairs.push({ question, answer });
+    }
+  }
+  return pairs.slice(0, 20);
+}

--- a/src/libs/filterItems.js
+++ b/src/libs/filterItems.js
@@ -42,10 +42,32 @@ const filterItems = (items, collection, filterItem, isProducts) => {
       // lone "(" or "+") straight in, and an unescaped one would throw.
       const escaped = makeText(filterItem).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const searchText = new RegExp(escaped, "i");
-      return items?.filter(
-        ({ title, category }) =>
-          searchText.test(title) || searchText.test(category)
-      );
+      const stripHtml = (html) =>
+        (html || "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ");
+      return items?.filter((item) => {
+        const {
+          title,
+          category,
+          desc,
+          summary,
+          subtitle,
+          tags,
+          html,
+          content,
+        } = item || {};
+        const tagText = Array.isArray(tags) ? tags.join(" ") : tags || "";
+        const haystack = [
+          title,
+          category,
+          desc,
+          summary,
+          subtitle,
+          tagText,
+          stripHtml(html),
+          typeof content === "string" ? content : "",
+        ].join(" ");
+        return searchText.test(haystack);
+      });
 
     case "popularity":
       return [...items]?.sort((a, b) => b.views - a.views);

--- a/src/libs/getBlogCategories.js
+++ b/src/libs/getBlogCategories.js
@@ -1,18 +1,23 @@
 import getBlogs from "./getBlogs";
 
+/**
+ * Categories sorted by post count descending (name ascending on ties).
+ * @returns {{ category: string, count: number }[]}
+ */
 const getBlogCategories = () => {
   const blogs = getBlogs();
+  const counts = {};
 
-  // Extract unique categories from actual blog data
-  const categories = blogs?.reduce((acc, blog) => {
-    if (blog.category && !acc.includes(blog.category)) {
-      acc.push(blog.category);
-    }
-    return acc;
-  }, []);
+  for (const blog of blogs || []) {
+    if (!blog?.category) continue;
+    counts[blog.category] = (counts[blog.category] || 0) + 1;
+  }
 
-  // Sort categories alphabetically
-  return categories?.sort();
+  return Object.entries(counts)
+    .sort(
+      (a, b) => b[1] - a[1] || a[0].localeCompare(b[0], undefined, { sensitivity: "base" })
+    )
+    .map(([category, count]) => ({ category, count }));
 };
 
 export default getBlogCategories;


### PR DESCRIPTION
## Summary
Closes the `next-gen-portfolio` items tracked in #26:

- Social links open in a new tab; Twitter/X replaced with Medium
- Categories sorted by post count (desc)
- Blog search matches title, summary/desc, tags, and body HTML
- Pagination stretches to the blog column width
- Copyright year uses the current year
- Leo stays chat-first (`speakByDefault: false`)
- “Read more” right-aligned; author name shows a LinkedIn hover card
- Single H1 on post pages (hero title is a `<p>`)
- Article typography ~18px / 1.5 lh / `max-w-[65ch]`
- Article + BreadcrumbList (+ FAQPage when FAQ section exists) JSON-LD
- Auto TOC when ≥4 H2s or ≥1500 words

## Test plan
- [ ] `/blogs` — categories ordered by count; search hits body/tags; pagination spans the post column; Read more on the right
- [ ] Hover/focus an author name — LinkedIn card appears; Esc/outside dismisses
- [ ] Open a long post — one H1, TOC present, prose measure ~65ch
- [ ] View page source / Rich Results — Article + BreadcrumbList JSON-LD
- [ ] Social icons (header/hero/footer/post share) open Medium/GitHub/LinkedIn in a new tab
- [ ] Leo opens as chat; voice stays muted until unmuted

Closes #26

Made with [Cursor](https://cursor.com)