### PR TITLE
fix: backlog #19–#21 (LinkedIn badge, scroll-top, contact map)

### DIFF
--- a/docs/superpowers/specs/2026-08-08-blog-ux-content-hygiene-backlog.md
+++ b/docs/superpowers/specs/2026-08-08-blog-ux-content-hygiene-backlog.md
@@ -1,9 +1,10 @@
 # next-gen-portfolio — Blog UX & SEO Backlog
 
 **Date:** 2026-08-08  
-**Status:** Open — recorded for resolution (not yet implemented)  
+**Status:** Mostly shipped (#32); open follow-ups **#19**–**#21**  
 **Repo:** `next-gen-portfolio` only  
-**GitHub:** https://github.com/mohansagark/next-gen-portfolio/issues/26  
+**GitHub (original):** https://github.com/mohansagark/next-gen-portfolio/issues/26  
+**GitHub (open follow-ups):** #33 · #35 · #36  
 
 **Sister backlog (digest):** https://github.com/mohansagark/daily-dev-digest/issues/12  
 `daily-dev-digest` → `docs/superpowers/specs/2026-08-08-content-slug-flux-hygiene-backlog.md`
@@ -12,21 +13,24 @@ IDs below are stable cross-repo numbers (gaps are intentional — those IDs live
 
 ## Summary (this repo)
 
-| # | Issue |
-|---|---|
-| 3 | Social links open in a new tab |
-| 4 | Replace Twitter with Medium (`https://mohansagark.medium.com/`) + icon |
-| 5 | Categories listed by post count descending |
-| 6 | Blog/category search covers title, header, body, tags, related content |
-| 7 | Stretch pagination to blog post content width |
-| 9 | Copyright year → **2026** |
-| 10 | Voice bot defaults to chat; voice only if visitor turns it on |
-| 11 | Move “Read more” button to the right side |
-| 12 | Author-name hover → small modal with LinkedIn profile card |
-| 13 | SEO: single H1 per post (no duplicate hero/article H1) |
-| 16 | SEO: article typography — ~18px body, 1.5 line-height, ~65ch measure |
-| 17 | SEO: Article + BreadcrumbList (+ FAQPage) JSON-LD |
-| 18 | SEO: TOC for long posts |
+| # | Issue | Status |
+|---|---|---|
+| 3 | Social links open in a new tab | Shipped (#32) |
+| 4 | Replace Twitter with Medium (`https://mohansagark.medium.com/`) + icon | Shipped (#32) |
+| 5 | Categories listed by post count descending | Shipped (#32) |
+| 6 | Blog/category search covers title, header, body, tags, related content | Shipped (#32) |
+| 7 | Stretch pagination to blog post content width | Shipped (#32) |
+| 9 | Copyright year → **2026** | Shipped (#32) |
+| 10 | Voice bot defaults to chat; voice only if visitor turns it on | Shipped (#32) |
+| 11 | Move “Read more” button to the right side | Shipped (#32) |
+| 12 | Author-name hover → LinkedIn profile card (custom card) | Shipped (#32) — see **#19** |
+| 13 | SEO: single H1 per post (no duplicate hero/article H1) | Shipped (#32) |
+| 16 | SEO: article typography — ~18px body, 1.5 line-height, ~65ch measure | Shipped (#32) |
+| 17 | SEO: Article + BreadcrumbList (+ FAQPage) JSON-LD | Shipped (#32) |
+| 18 | SEO: TOC for long posts | Shipped (#32) |
+| **19** | **Author hover uses LinkedIn official profile badge (not custom card)** | **Open (#33)** |
+| **20** | **Move scroll-to-top control to bottom-left (chatbot overlap)** | **Open (#35)** |
+| **21** | **Contact section: map view container (not address text only)** | **Open (#36)** |
 
 ---
 
@@ -84,6 +88,8 @@ IDs below are stable cross-repo numbers (gaps are intentional — those IDs live
 
 **Desired:** On hover (and accessible focus), open a **small modal/popover** showing a **LinkedIn profile card** for the author (Mohan’s LinkedIn). Dismiss on mouse leave / Esc / outside click; keyboard-accessible.
 
+**Shipped:** Custom hover card in #32. Superseded for presentation by **#19** (official LinkedIn badge).
+
 ## 13. SEO — single H1 per post
 
 **Problem:** Post pages can expose more than one `<h1>` (hero title + article title).
@@ -108,6 +114,71 @@ IDs below are stable cross-repo numbers (gaps are intentional — those IDs live
 
 **Desired:** Auto TOC from H2/H3 with anchor links when post length exceeds a threshold (e.g. ≥ ~1,500 words or ≥ 4 H2s).
 
+## 19. Author hover → LinkedIn official profile badge
+
+**GitHub:** https://github.com/mohansagark/next-gen-portfolio/issues/33  
+**Follow-up to:** #12 (custom card shipped in #32)
+
+**Problem:** Author hover uses a **hand-built** LinkedIn-style card. Product intent is LinkedIn’s **official badge banner**, not a custom mock.
+
+**Desired:** On author-name hover / focus, show LinkedIn’s profile badge for vanity `mohansagark`. Load the official script once; pick light/dark theme to match the site; keep Esc / outside-click / mouse-leave dismiss and keyboard access.
+
+**Script:**
+
+```html
+<script src="https://platform.linkedin.com/badges/js/profile.js" async defer type="text/javascript"></script>
+```
+
+**Light badge:**
+
+```html
+<div class="badge-base LI-profile-badge" data-locale="en_US" data-size="large" data-theme="light" data-type="HORIZONTAL" data-vanity="mohansagark" data-version="v1">
+  <a class="badge-base__link LI-simple-link" href="https://in.linkedin.com/in/mohansagark?trk=profile-badge">Mohan Sagar Killamsetty</a>
+</div>
+```
+
+**Dark badge:**
+
+```html
+<div class="badge-base LI-profile-badge" data-locale="en_US" data-size="large" data-theme="dark" data-type="HORIZONTAL" data-vanity="mohansagark" data-version="v1">
+  <a class="badge-base__link LI-simple-link" href="https://in.linkedin.com/in/mohansagark?trk=profile-badge">Mohan Sagar Killamsetty</a>
+</div>
+```
+
+**Implementation notes:**
+- Replace custom markup in `AuthorDisplay.js`.
+- Use `next/script` (or equivalent) so the badge script loads once; re-run badge init if the widget mounts after hover.
+- `data-theme` should follow site light/dark mode.
+
+## 20. Scroll-to-top → bottom-left (avoid chatbot overlap)
+
+**GitHub:** https://github.com/mohansagark/next-gen-portfolio/issues/35  
+
+**Problem:** The scroll-to-top control (`BackToTop` / `#scrollUp` / `.progress-wrap`) is anchored **bottom-right**. Leo’s chatbot orb also sits bottom-right and **completely overlaps** the scroll-to-top icon, so it cannot be used.
+
+**Desired:** Move scroll-to-top to the **bottom-left** (with sensible edge / safe-area margin) so it no longer collides with the chatbot.
+
+**Acceptance:**
+- Visible and clickable on desktop and mobile
+- No overlap with Leo / chatbot orb
+- Adequate clearance from screen edges
+
+## 21. Contact section — map view container
+
+**GitHub:** https://github.com/mohansagark/next-gen-portfolio/issues/36  
+**Surface:** Main contact (`Contact1`) — Address currently shows `profile.location` as text only
+
+**Problem:** Location is plain text (e.g. Hyderabad). No map / place visual, so address feels weaker than phone/email.
+
+**Desired:** Add a **map view container** in the contact section. Prefer an embedded interactive map (Google Maps / OpenStreetMap iframe) for the configured location; keep the address text as a label or caption (not an empty iframe with no readable address).
+
+**Acceptance:**
+- Visible map container on desktop and mobile
+- Reflects profile location
+- Address text remains readable
+- Contact form column layout intact
+- Looks intentional in light and dark mode
+
 ---
 
 ## Out of scope (this repo)
@@ -118,8 +189,11 @@ IDs below are stable cross-repo numbers (gaps are intentional — those IDs live
 
 ## Suggested execution order (this repo)
 
-1. Quick UI: #3, #4, #5, #7, #9, #11  
-2. Author LinkedIn hover: #12  
-3. Voice default: #10  
-4. SEO template: #13, #16, #17, #18  
-5. Search depth: #6  
+1. ~~Quick UI: #3, #4, #5, #7, #9, #11~~ (shipped #32)  
+2. ~~Author LinkedIn hover: #12~~ (custom card shipped #32) → **#19 official badge**  
+3. ~~Voice default: #10~~ (shipped #32)  
+4. ~~SEO template: #13, #16, #17, #18~~ (shipped #32)  
+5. ~~Search depth: #6~~ (shipped #32)  
+6. **Next:** #19 LinkedIn official badge  
+7. **Next:** #20 Scroll-to-top → bottom-left  
+8. **Next:** #21 Contact map view container  

--- a/src/app/css/backToTop.css
+++ b/src/app/css/backToTop.css
@@ -1,6 +1,8 @@
 .progress-wrap {
   position: fixed;
-  right: 30px;
+  /* Bottom-left so Leo's chatbot orb (bottom-right) does not cover this control. */
+  left: 30px;
+  right: auto;
   bottom: 25px;
   height: 46px;
   width: 46px;
@@ -55,7 +57,8 @@
 
 @media (max-width: 767px) {
   .progress-wrap {
-    right: 15px;
+    left: 15px;
+    right: auto;
     bottom: 15px;
   }
 }

--- a/src/components/sections/contact/Contact1.js
+++ b/src/components/sections/contact/Contact1.js
@@ -225,22 +225,40 @@ const Contact1 = () => {
                     </div>
                   </li>
                   <li
-                    className="flex  items-center gap-25px position-relative wow fadeInRight"
+                    className="flex flex-col gap-4 position-relative wow fadeInRight"
                     data-wow-delay=".6s"
                   >
-                    <div className="icon-box text-xl flex-shrink-0 w-50px h-50px text-white-color flex justify-center items-center flex-col bg-gradient-primary-2 rounded-full leading-1">
-                      <i className="flaticon-location leading-1 mt-1"></i>
+                    <div className="flex items-center gap-25px">
+                      <div className="icon-box text-xl flex-shrink-0 w-50px h-50px text-white-color flex justify-center items-center flex-col bg-gradient-primary-2 rounded-full leading-1">
+                        <i className="flaticon-location leading-1 mt-1"></i>
+                      </div>
+                      <div className="text-box">
+                        <p className="text-primary-color-light dark:text-white-color mb-1">
+                          Address
+                        </p>
+                        <a
+                          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+                            profile.location
+                          )}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary-color-light dark:text-white-color text-lg lg:text-xl font-medium hover:text-primary-color"
+                        >
+                          {profile.location}
+                        </a>
+                      </div>
                     </div>
-                    <div className="text-box">
-                      <p className="text-primary-color-light dark:text-white-color mb-1">
-                        Address
-                      </p>
-                      <a
-                        href="#"
-                        className="text-primary-color-light dark:text-white-color text-lg lg:text-xl font-medium hover:text-primary-color"
-                      >
-                        {profile.location}
-                      </a>
+                    <div className="w-full rounded-15px overflow-hidden border-2 border-body-color dark:border-bg-color-2 bg-white-color dark:bg-primary-color-light">
+                      <iframe
+                        title={`Map of ${profile.location}`}
+                        src={`https://www.google.com/maps?q=${encodeURIComponent(
+                          profile.location
+                        )}&z=12&output=embed`}
+                        className="block w-full h-[220px] md:h-[260px] border-0"
+                        loading="lazy"
+                        referrerPolicy="no-referrer-when-downgrade"
+                        allowFullScreen
+                      />
                     </div>
                   </li>
                 </ul>

--- a/src/components/sections/contact/Contact1.js
+++ b/src/components/sections/contact/Contact1.js
@@ -5,6 +5,9 @@ import getProfile from "@/libs/getProfile";
 
 const Contact1 = () => {
   const profile = getProfile();
+  // CMS may return a profile object without a usable location — the fallback in
+  // getProfile only kicks in when the whole profile key is missing.
+  const location = profile.location?.trim();
   const form = useRef();
   const [formData, setFormData] = useState({
     first_name: "",
@@ -224,43 +227,45 @@ const Contact1 = () => {
                       </a>
                     </div>
                   </li>
-                  <li
-                    className="flex flex-col gap-4 position-relative wow fadeInRight"
-                    data-wow-delay=".6s"
-                  >
-                    <div className="flex items-center gap-25px">
-                      <div className="icon-box text-xl flex-shrink-0 w-50px h-50px text-white-color flex justify-center items-center flex-col bg-gradient-primary-2 rounded-full leading-1">
-                        <i className="flaticon-location leading-1 mt-1"></i>
+                  {location ? (
+                    <li
+                      className="flex flex-col gap-4 position-relative wow fadeInRight"
+                      data-wow-delay=".6s"
+                    >
+                      <div className="flex items-center gap-25px">
+                        <div className="icon-box text-xl flex-shrink-0 w-50px h-50px text-white-color flex justify-center items-center flex-col bg-gradient-primary-2 rounded-full leading-1">
+                          <i className="flaticon-location leading-1 mt-1"></i>
+                        </div>
+                        <div className="text-box">
+                          <p className="text-primary-color-light dark:text-white-color mb-1">
+                            Address
+                          </p>
+                          <a
+                            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+                              location
+                            )}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-primary-color-light dark:text-white-color text-lg lg:text-xl font-medium hover:text-primary-color"
+                          >
+                            {location}
+                          </a>
+                        </div>
                       </div>
-                      <div className="text-box">
-                        <p className="text-primary-color-light dark:text-white-color mb-1">
-                          Address
-                        </p>
-                        <a
-                          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-                            profile.location
-                          )}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-primary-color-light dark:text-white-color text-lg lg:text-xl font-medium hover:text-primary-color"
-                        >
-                          {profile.location}
-                        </a>
+                      <div className="w-full rounded-15px overflow-hidden border-2 border-body-color dark:border-bg-color-2 bg-white-color dark:bg-primary-color-light">
+                        <iframe
+                          title={`Map of ${location}`}
+                          src={`https://www.google.com/maps?q=${encodeURIComponent(
+                            location
+                          )}&z=12&output=embed`}
+                          className="block w-full h-[220px] md:h-[260px] border-0"
+                          loading="lazy"
+                          referrerPolicy="no-referrer-when-downgrade"
+                          allowFullScreen
+                        />
                       </div>
-                    </div>
-                    <div className="w-full rounded-15px overflow-hidden border-2 border-body-color dark:border-bg-color-2 bg-white-color dark:bg-primary-color-light">
-                      <iframe
-                        title={`Map of ${profile.location}`}
-                        src={`https://www.google.com/maps?q=${encodeURIComponent(
-                          profile.location
-                        )}&z=12&output=embed`}
-                        className="block w-full h-[220px] md:h-[260px] border-0"
-                        loading="lazy"
-                        referrerPolicy="no-referrer-when-downgrade"
-                        allowFullScreen
-                      />
-                    </div>
-                  </li>
+                    </li>
+                  ) : null}
                 </ul>
               </div>
             </div>

--- a/src/components/shared/AuthorDisplay.js
+++ b/src/components/shared/AuthorDisplay.js
@@ -1,25 +1,73 @@
 "use client";
 
-import Script from "next/script";
-import React, { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 const LINKEDIN_VANITY = "mohansagark";
 const LINKEDIN_URL = `https://in.linkedin.com/in/${LINKEDIN_VANITY}?trk=profile-badge`;
 const LINKEDIN_LABEL = "Mohan Sagar Killamsetty";
+const LINKEDIN_SCRIPT_SRC = "https://platform.linkedin.com/badges/js/profile.js";
+const PANEL_GAP = 8;
+const VIEWPORT_MARGIN = 16;
+const CLOSE_DELAY = 200;
 
-function useIsDarkTheme() {
-  const [isDark, setIsDark] = useState(true);
+// One shared <script> for the whole page, loaded on first hover only.
+// Rendering it per instance is wrong: the loader dedupes on src, so every
+// instance after the first silently never fires onLoad.
+let scriptPromise = null;
 
-  useEffect(() => {
-    const html = document.documentElement;
-    const sync = () => setIsDark(html.classList.contains("dark"));
-    sync();
-    const obs = new MutationObserver(sync);
-    obs.observe(html, { attributes: true, attributeFilter: ["class"] });
-    return () => obs.disconnect();
-  }, []);
+function loadLinkedInScript() {
+  if (typeof window === "undefined") return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise((resolve) => {
+    const el = document.createElement("script");
+    el.src = LINKEDIN_SCRIPT_SRC;
+    el.async = true;
+    el.onload = () => resolve();
+    el.onerror = () => resolve(); // fallback link stays usable
+    document.body.appendChild(el);
+  });
+  return scriptPromise;
+}
 
-  return isDark;
+// One shared MutationObserver instead of one per author instance.
+const themeListeners = new Set();
+let themeObserver = null;
+
+function subscribeTheme(listener) {
+  themeListeners.add(listener);
+  if (!themeObserver) {
+    themeObserver = new MutationObserver(() => {
+      themeListeners.forEach((cb) => cb());
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+  }
+  return () => {
+    themeListeners.delete(listener);
+    if (themeListeners.size === 0 && themeObserver) {
+      themeObserver.disconnect();
+      themeObserver = null;
+    }
+  };
+}
+
+function readTheme() {
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+function useTheme() {
+  return useSyncExternalStore(subscribeTheme, readTheme, () => "dark");
 }
 
 function renderLinkedInBadges() {
@@ -29,18 +77,63 @@ function renderLinkedInBadges() {
   }
 }
 
-const AuthorDisplay = ({
-  author,
-  className = "",
-  showBy = true,
-}) => {
+const AuthorDisplay = ({ author, className = "", showBy = true }) => {
   const isBot = author === "Agent Bot";
   const [open, setOpen] = useState(false);
   const [scriptReady, setScriptReady] = useState(false);
   const rootRef = useRef(null);
+  const panelRef = useRef(null);
+  const closeTimer = useRef(null);
   const panelId = useId();
-  const isDark = useIsDarkTheme();
-  const theme = isDark ? "dark" : "light";
+  const theme = useTheme();
+
+  const cancelClose = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, []);
+
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimer.current = setTimeout(() => setOpen(false), CLOSE_DELAY);
+  }, [cancelClose]);
+
+  const openPanel = useCallback(() => {
+    cancelClose();
+    setOpen(true);
+    loadLinkedInScript().then(() => setScriptReady(true));
+  }, [cancelClose]);
+
+  useEffect(() => cancelClose, [cancelClose]);
+
+  // The panel is portalled to the end of <body>, so Tab from the trigger would
+  // skip past it — hand focus over explicitly for keyboard users.
+  const handingOff = useRef(false);
+
+  const onTriggerKeyDown = (e) => {
+    if (e.key !== "Tab" || e.shiftKey || !open) return;
+    const target = panelRef.current?.querySelector("a, iframe, [tabindex]");
+    if (!target) return;
+    e.preventDefault();
+    handingOff.current = true;
+    target.focus();
+    setTimeout(() => {
+      handingOff.current = false;
+    }, 0);
+  };
+
+  const onTriggerBlur = (e) => {
+    if (handingOff.current) return;
+    if (panelRef.current?.contains(e.relatedTarget)) return;
+    scheduleClose();
+  };
+
+  const onPanelBlur = (e) => {
+    if (panelRef.current?.contains(e.relatedTarget)) return;
+    if (rootRef.current?.contains(e.relatedTarget)) return;
+    scheduleClose();
+  };
 
   useEffect(() => {
     if (!open) return;
@@ -48,9 +141,9 @@ const AuthorDisplay = ({
       if (e.key === "Escape") setOpen(false);
     };
     const onPointer = (e) => {
-      if (rootRef.current && !rootRef.current.contains(e.target)) {
-        setOpen(false);
-      }
+      const inRoot = rootRef.current?.contains(e.target);
+      const inPanel = panelRef.current?.contains(e.target);
+      if (!inRoot && !inPanel) setOpen(false);
     };
     document.addEventListener("keydown", onKey);
     document.addEventListener("pointerdown", onPointer);
@@ -59,6 +152,42 @@ const AuthorDisplay = ({
       document.removeEventListener("pointerdown", onPointer);
     };
   }, [open]);
+
+  // Panel is portalled to <body> so card ancestors with overflow-hidden cannot
+  // clip it; position it against the trigger and keep it inside the viewport.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const place = () => {
+      const panel = panelRef.current;
+      const root = rootRef.current;
+      if (!panel || !root) return;
+      const anchor = root.getBoundingClientRect();
+      const { offsetWidth: width, offsetHeight: height } = panel;
+      const maxLeft = window.innerWidth - width - VIEWPORT_MARGIN;
+      const left = Math.min(
+        Math.max(VIEWPORT_MARGIN, anchor.left),
+        Math.max(VIEWPORT_MARGIN, maxLeft)
+      );
+      const below = anchor.bottom + PANEL_GAP;
+      const flip =
+        below + height > window.innerHeight - VIEWPORT_MARGIN &&
+        anchor.top - height - PANEL_GAP > VIEWPORT_MARGIN;
+      panel.style.left = `${left}px`;
+      panel.style.top = `${flip ? anchor.top - height - PANEL_GAP : below}px`;
+    };
+
+    place();
+    window.addEventListener("scroll", place, true);
+    window.addEventListener("resize", place);
+    // Badge iframe resizes once LinkedIn paints it — reposition when it does.
+    const observer = new ResizeObserver(place);
+    if (panelRef.current) observer.observe(panelRef.current);
+    return () => {
+      window.removeEventListener("scroll", place, true);
+      window.removeEventListener("resize", place);
+      observer.disconnect();
+    };
+  }, [open, theme, scriptReady]);
 
   // LinkedIn only paints badges present at script load; re-scan after hover mount.
   useEffect(() => {
@@ -77,21 +206,49 @@ const AuthorDisplay = ({
     );
   }
 
+  const panel = (
+    <div
+      ref={panelRef}
+      id={panelId}
+      role="dialog"
+      aria-label={`${author} LinkedIn profile`}
+      className="fixed z-[1000] text-left normal-case"
+      style={{ top: -9999, left: -9999, maxWidth: `calc(100vw - ${VIEWPORT_MARGIN * 2}px)` }}
+      onMouseEnter={cancelClose}
+      onMouseLeave={scheduleClose}
+      onBlur={onPanelBlur}
+    >
+      <div className="rounded-lg border border-border-color dark:border-gray-color-3 bg-white dark:bg-primary-color-light p-2 shadow-lg overflow-auto">
+        <div
+          key={theme}
+          className="badge-base LI-profile-badge"
+          data-locale="en_US"
+          data-size="medium"
+          data-theme={theme}
+          data-type="HORIZONTAL"
+          data-vanity={LINKEDIN_VANITY}
+          data-version="v1"
+        >
+          <a
+            className="badge-base__link LI-simple-link"
+            href={LINKEDIN_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {LINKEDIN_LABEL}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <span
       ref={rootRef}
       className={`relative inline-flex items-center gap-1 ${className}`}
-      onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
+      onMouseEnter={openPanel}
+      onMouseLeave={scheduleClose}
     >
-      <Script
-        src="https://platform.linkedin.com/badges/js/profile.js"
-        strategy="lazyOnload"
-        onLoad={() => {
-          setScriptReady(true);
-          renderLinkedInBadges();
-        }}
-      />
       {showBy ? <span>By</span> : null}
       <i className="fa-solid fa-user" title="Human Author" aria-hidden="true"></i>
       <button
@@ -99,42 +256,17 @@ const AuthorDisplay = ({
         className="text-inherit capitalize hover:text-primary-color transition-colors duration-300 underline-offset-2 hover:underline bg-transparent border-0 p-0 cursor-pointer font-inherit"
         aria-expanded={open}
         aria-controls={panelId}
-        onFocus={() => setOpen(true)}
-        onClick={() => setOpen(true)}
+        onFocus={openPanel}
+        onBlur={onTriggerBlur}
+        onKeyDown={onTriggerKeyDown}
+        onClick={openPanel}
       >
         {author}
       </button>
 
-      {open ? (
-        <div
-          id={panelId}
-          role="dialog"
-          aria-label={`${author} LinkedIn profile`}
-          className="absolute left-0 top-full z-50 pt-2 w-[min(100vw-2rem,340px)] text-left normal-case"
-        >
-          <div className="rounded-lg border border-border-color dark:border-gray-color-3 bg-white dark:bg-primary-color-light p-2 shadow-lg overflow-hidden">
-            <div
-              key={theme}
-              className="badge-base LI-profile-badge"
-              data-locale="en_US"
-              data-size="large"
-              data-theme={theme}
-              data-type="HORIZONTAL"
-              data-vanity={LINKEDIN_VANITY}
-              data-version="v1"
-            >
-              <a
-                className="badge-base__link LI-simple-link"
-                href={LINKEDIN_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {LINKEDIN_LABEL}
-              </a>
-            </div>
-          </div>
-        </div>
-      ) : null}
+      {open && typeof document !== "undefined"
+        ? createPortal(panel, document.body)
+        : null}
     </span>
   );
 };

--- a/src/components/shared/AuthorDisplay.js
+++ b/src/components/shared/AuthorDisplay.js
@@ -1,22 +1,46 @@
 "use client";
 
-import Link from "next/link";
+import Script from "next/script";
 import React, { useEffect, useId, useRef, useState } from "react";
 
-const LINKEDIN_URL = "https://www.linkedin.com/in/mohansagark/";
+const LINKEDIN_VANITY = "mohansagark";
+const LINKEDIN_URL = `https://in.linkedin.com/in/${LINKEDIN_VANITY}?trk=profile-badge`;
 const LINKEDIN_LABEL = "Mohan Sagar Killamsetty";
-const LINKEDIN_HEADLINE = "Software Engineer · Dev Mohan";
+
+function useIsDarkTheme() {
+  const [isDark, setIsDark] = useState(true);
+
+  useEffect(() => {
+    const html = document.documentElement;
+    const sync = () => setIsDark(html.classList.contains("dark"));
+    sync();
+    const obs = new MutationObserver(sync);
+    obs.observe(html, { attributes: true, attributeFilter: ["class"] });
+    return () => obs.disconnect();
+  }, []);
+
+  return isDark;
+}
+
+function renderLinkedInBadges() {
+  if (typeof window === "undefined") return;
+  if (typeof window.LIRenderAll === "function") {
+    window.LIRenderAll();
+  }
+}
 
 const AuthorDisplay = ({
   author,
   className = "",
   showBy = true,
-  linkedInUrl = LINKEDIN_URL,
 }) => {
   const isBot = author === "Agent Bot";
   const [open, setOpen] = useState(false);
+  const [scriptReady, setScriptReady] = useState(false);
   const rootRef = useRef(null);
   const panelId = useId();
+  const isDark = useIsDarkTheme();
+  const theme = isDark ? "dark" : "light";
 
   useEffect(() => {
     if (!open) return;
@@ -36,6 +60,13 @@ const AuthorDisplay = ({
     };
   }, [open]);
 
+  // LinkedIn only paints badges present at script load; re-scan after hover mount.
+  useEffect(() => {
+    if (!open || !scriptReady) return;
+    const id = window.requestAnimationFrame(() => renderLinkedInBadges());
+    return () => window.cancelAnimationFrame(id);
+  }, [open, scriptReady, theme]);
+
   if (isBot) {
     return (
       <span className={`inline-flex items-center gap-1 ${className}`}>
@@ -53,6 +84,14 @@ const AuthorDisplay = ({
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
     >
+      <Script
+        src="https://platform.linkedin.com/badges/js/profile.js"
+        strategy="lazyOnload"
+        onLoad={() => {
+          setScriptReady(true);
+          renderLinkedInBadges();
+        }}
+      />
       {showBy ? <span>By</span> : null}
       <i className="fa-solid fa-user" title="Human Author" aria-hidden="true"></i>
       <button
@@ -71,28 +110,27 @@ const AuthorDisplay = ({
           id={panelId}
           role="dialog"
           aria-label={`${author} LinkedIn profile`}
-          className="absolute left-0 top-full z-50 mt-2 w-72 rounded-lg border border-border-color dark:border-gray-color-3 bg-white dark:bg-primary-color-light p-4 shadow-lg text-left normal-case"
+          className="absolute left-0 top-full z-50 pt-2 w-[min(100vw-2rem,340px)] text-left normal-case"
         >
-          <div className="flex items-start gap-3">
-            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[#0A66C2] text-white text-lg">
-              <i className="fa-brands fa-linkedin-in" aria-hidden="true"></i>
-            </span>
-            <div className="min-w-0">
-              <p className="text-sm font-bold text-primary-color-light dark:text-white-color leading-snug">
-                {LINKEDIN_LABEL}
-              </p>
-              <p className="text-xs text-body-color dark:text-gray-color mt-0.5 leading-snug">
-                {LINKEDIN_HEADLINE}
-              </p>
-              <Link
-                href={linkedInUrl}
+          <div className="rounded-lg border border-border-color dark:border-gray-color-3 bg-white dark:bg-primary-color-light p-2 shadow-lg overflow-hidden">
+            <div
+              key={theme}
+              className="badge-base LI-profile-badge"
+              data-locale="en_US"
+              data-size="large"
+              data-theme={theme}
+              data-type="HORIZONTAL"
+              data-vanity={LINKEDIN_VANITY}
+              data-version="v1"
+            >
+              <a
+                className="badge-base__link LI-simple-link"
+                href={LINKEDIN_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-[#0A66C2] hover:underline"
               >
-                View LinkedIn profile
-                <i className="fa-solid fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>
-              </Link>
+                {LINKEDIN_LABEL}
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Implements open follow-ups after #32:

- **#19 / #33** — Author hover uses LinkedIn’s **official** profile badge (script + light/dark `data-theme`), not the custom card
- **#20 / #35** — Scroll-to-top moves to **bottom-left** so Leo’s orb no longer covers it
- **#21 / #36** — Contact section gets a **map iframe** for `profile.location`, with address text kept as a caption/link

Also updates the backlog doc and supersedes the docs-only PR #34.

## Test plan
- [ ] Hover author name on `/blogs` — official LinkedIn badge renders; theme flips with site dark/light
- [ ] Scroll down — progress/scroll-up control is bottom-left and clickable; Leo stays bottom-right
- [ ] Home `#contact` — map container visible under Address; address text still readable and opens Maps
- [ ] Mobile: map + scroll control still usable

Closes #33
Closes #35
Closes #36

Made with [Cursor](https://cursor.com)