### PR TITLE
fix(blog): pagination, mobile search, and no-cover card layout

### DIFF
--- a/src/components/sections/blogs/BlogsPrimary.js
+++ b/src/components/sections/blogs/BlogsPrimary.js
@@ -2,6 +2,7 @@ import BlogQuote from "@/components/shared/blogs/BlogQuote";
 import BlogSingle from "@/components/shared/blogs/BlogSingle";
 import Paginations from "@/components/shared/others/Paginations";
 import BlogSidebar from "@/components/shared/sidebar/BlogSidebar";
+import BlogSearchWidget from "@/components/shared/sidebar/widgets/BlogSearchWidget";
 import { useCommonContext } from "@/context_api/CommonContext";
 import usePagination from "@/hooks/usePagination";
 import React from "react";
@@ -27,9 +28,14 @@ const BlogsPrimary = () => {
     <section id="blogs">
       <div className="py-60px md:py-20 lg:py-100px xl:py-30 dark:bg-black-color">
         <div className="container">
-          <div className="lg:grid lg:gap-6 lg:grid-cols-12">
+          <div className="flex flex-col gap-10 lg:grid lg:gap-6 lg:grid-cols-12">
+            {/* Mobile only: search above the blog list */}
+            <div className="order-1 lg:hidden">
+              <BlogSearchWidget />
+            </div>
+
             {/* <!-- blogs --> */}
-            <div className="flex flex-col gap-10 lg:col-start-1 lg:col-span-8">
+            <div className="order-2 lg:order-1 flex flex-col gap-10 lg:col-start-1 lg:col-span-8">
               {currentItems?.length
                 ? currentItems?.map((blog, idx) =>
                     blog?.isBlogQuote ? (
@@ -59,7 +65,8 @@ const BlogsPrimary = () => {
                 ""
               )}
             </div>
-            {/* <!-- sidebar --> */}
+
+            {/* Categories / recent / tags: after posts on mobile, right column on desktop */}
             <BlogSidebar />
           </div>
         </div>

--- a/src/components/sections/blogs/BlogsPrimary.js
+++ b/src/components/sections/blogs/BlogsPrimary.js
@@ -25,7 +25,7 @@ const BlogsPrimary = () => {
   const totalBlogs = filteredBlogs?.length;
   const totalBlogsToShow = currentItems?.length;
   return (
-    <section id="blogs">
+    <section id="blogs" className="scroll-mt-24 lg:scroll-mt-28">
       <div className="py-60px md:py-20 lg:py-100px xl:py-30 dark:bg-black-color">
         <div className="container">
           <div className="flex flex-col gap-10 lg:grid lg:gap-6 lg:grid-cols-12">

--- a/src/components/sections/blogs/BlogsPrimary.js
+++ b/src/components/sections/blogs/BlogsPrimary.js
@@ -67,7 +67,7 @@ const BlogsPrimary = () => {
             </div>
 
             {/* Categories / recent / tags: after posts on mobile, right column on desktop */}
-            <BlogSidebar />
+            <BlogSidebar mobileSearchElsewhere />
           </div>
         </div>
       </div>

--- a/src/components/shared/blogs/BlogSingle.js
+++ b/src/components/shared/blogs/BlogSingle.js
@@ -5,6 +5,9 @@ import React from "react";
 import countCommentLength from "@/libs/countCommentLength";
 import AuthorDisplay from "@/components/shared/AuthorDisplay";
 
+const categoryPillClass =
+  "text-size-13 uppercase px-15px py-10px rounded-50px leading-1 text-white-color bg-gradient-secondary-2 bg-200 hover:bg-100";
+
 const BlogSingle = ({ blog }) => {
   const {
     id,
@@ -18,70 +21,113 @@ const BlogSingle = ({ blog }) => {
     coverImageAlt,
   } = blog ? blog : {};
 
+  const renderMetaItems = (keyPrefix) => (
+    <>
+      {blogTopList?.length
+        ? blogTopList.map(({ iconName, name, path }, idx) => (
+            <li
+              key={`${keyPrefix}-${idx}`}
+              className="text-primary-color dark:text-white-color"
+            >
+              {path ? (
+                <AuthorDisplay
+                  author={author || name}
+                  className="text-primary-color dark:text-white-color"
+                />
+              ) : (
+                <>
+                  <i
+                    className={`${iconName} mr-1 text-primary-color transition-all duration-500`}
+                  ></i>{" "}
+                  {name}
+                </>
+              )}
+            </li>
+          ))
+        : null}
+      {comments && comments.length > 0 ? (
+        <li
+          key={`${keyPrefix}-comments`}
+          className="text-primary-color dark:text-white-color"
+        >
+          <i className="fa-regular fa-comments mr-1 text-primary-color transition-all duration-500"></i>{" "}
+          <Link
+            href={`/blogs/${id}#comment-reply`}
+            className="text-primary-color dark:text-white-color hover:text-primary-color transition-all duration-500"
+          >
+            Comments ({countCommentLength(comments)})
+          </Link>
+        </li>
+      ) : null}
+    </>
+  );
+
   return (
     <article className="group relative  wow fadeInUp" data-wow-delay=".3s">
       <div className="rounded-lg relative overflow-hidden bg-cream-light-color dark:bg-primary-color-light">
         {coverImage ? (
+          <div className="relative">
+            <Link
+              href={`/blogs/${id}`}
+              className="block relative aspect-[16/9] overflow-hidden rounded-t-lg"
+            >
+              <Image
+                src={coverImage}
+                alt={coverImageAlt || ""}
+                fill
+                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                className="object-cover group-hover:scale-110 transition-all duration-[.8s]"
+              />
+            </Link>
+            {category ? (
+              <Link
+                href={`/blogs?category=${makePath(category)}`}
+                className={`${categoryPillClass} absolute top-[15px] right-[15px] z-10`}
+              >
+                {category}
+              </Link>
+            ) : null}
+          </div>
+        ) : category ? (
+          // No cover, desktop: previous absolute top-right tag
           <Link
-            href={`/blogs/${id}`}
-            className="block relative aspect-[16/9] overflow-hidden rounded-t-lg"
+            href={`/blogs?category=${makePath(category)}`}
+            className={`${categoryPillClass} absolute top-[15px] right-[15px] z-10 hidden md:inline-flex`}
           >
-            <Image
-              src={coverImage}
-              alt={coverImageAlt || ""}
-              fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              className="object-cover group-hover:scale-110 transition-all duration-[.8s]"
-            />
+            {category}
           </Link>
         ) : null}
-        <Link
-          href={`/blogs?category=${makePath(category)}`}
-          className="text-size-13 uppercase px-15px py-10px rounded-50px leading-1 absolute top-[15px] right-[15px] text-white-color bg-gradient-secondary-2 bg-200 hover:bg-100"
-        >
-          {category}
-        </Link>
 
         <div className="py-25px px-15px md:p-30px -mt-10px">
           <div className="transition-all duration-500">
             <div className="relative z-0">
               <div className="relative z-10">
-                <ul className="flex flex-wrap gap-x-15px gap-y-10px md:gap-25px items-center mb-5">
-                  {blogTopList?.length
-                    ? blogTopList?.map(({ iconName, name, path }, idx) => (
-                        <li
-                          key={1000 + idx}
-                          className="text-primary-color dark:text-white-color "
+                {!coverImage ? (
+                  <>
+                    {/* Mobile: date + author stacked left, tag right */}
+                    <div className="flex md:hidden items-start justify-between gap-3 mb-5">
+                      <ul className="flex flex-col gap-2 min-w-0">
+                        {renderMetaItems("mobile")}
+                      </ul>
+                      {category ? (
+                        <Link
+                          href={`/blogs?category=${makePath(category)}`}
+                          className={`${categoryPillClass} shrink-0`}
                         >
-                          {path ? (
-                            <AuthorDisplay
-                              author={author || name}
-                              className="text-primary-color dark:text-white-color"
-                            />
-                          ) : (
-                            <>
-                              <i
-                                className={`${iconName} mr-1 text-primary-color transition-all duration-500`}
-                              ></i>{" "}
-                              {name}
-                            </>
-                          )}
-                        </li>
-                      ))
-                    : ""}
-                  {/* Comments count as separate item */}
-                  {comments && comments.length > 0 && (
-                    <li className="text-primary-color dark:text-white-color">
-                      <i className="fa-regular fa-comments mr-1 text-primary-color transition-all duration-500"></i>{" "}
-                      <Link
-                        href={`/blogs/${id}#comment-reply`}
-                        className="text-primary-color dark:text-white-color hover:text-primary-color transition-all duration-500"
-                      >
-                        Comments ({countCommentLength(comments)})
-                      </Link>
-                    </li>
-                  )}
-                </ul>
+                          {category}
+                        </Link>
+                      ) : null}
+                    </div>
+                    {/* Desktop: previous horizontal meta row */}
+                    <ul className="hidden md:flex flex-wrap gap-x-15px gap-y-10px md:gap-25px items-center mb-5">
+                      {renderMetaItems("desktop")}
+                    </ul>
+                  </>
+                ) : (
+                  <ul className="flex flex-wrap gap-x-15px gap-y-10px md:gap-25px items-center mb-5">
+                    {renderMetaItems("cover")}
+                  </ul>
+                )}
                 <h3 className="mb-15px md:mb-5">
                   <Link
                     href={`/blogs/${id}`}
@@ -96,9 +142,10 @@ const BlogSingle = ({ blog }) => {
                 <div className="flex justify-end">
                   <Link
                     href={`/blogs/${id}`}
-                    className="text-size-15 font-bold text-white-color capitalize py-17px px-35px bg-200 bg-gradient-secondary hover:bg-[-100%] rounded-full leading-1 transition-all duration-300"
+                    className="inline-flex items-center gap-2 text-size-15 font-bold text-white-color py-17px px-35px bg-200 bg-gradient-secondary hover:bg-[-100%] rounded-full leading-1 transition-all duration-300"
                   >
-                    Read more
+                    View Full Post
+                    <i className="fal fa-arrow-right text-sm" aria-hidden="true"></i>
                   </Link>
                 </div>
               </div>

--- a/src/components/shared/blogs/BlogSingle.js
+++ b/src/components/shared/blogs/BlogSingle.js
@@ -103,26 +103,24 @@ const BlogSingle = ({ blog }) => {
             <div className="relative z-0">
               <div className="relative z-10">
                 {!coverImage ? (
-                  <>
-                    {/* Mobile: date + author stacked left, tag right */}
-                    <div className="flex md:hidden items-start justify-between gap-3 mb-5">
-                      <ul className="flex flex-col gap-2 min-w-0">
-                        {renderMetaItems("mobile")}
-                      </ul>
-                      {category ? (
-                        <Link
-                          href={`/blogs?category=${makePath(category)}`}
-                          className={`${categoryPillClass} shrink-0`}
-                        >
-                          {category}
-                        </Link>
-                      ) : null}
-                    </div>
-                    {/* Desktop: previous horizontal meta row */}
-                    <ul className="hidden md:flex flex-wrap gap-x-15px gap-y-10px md:gap-25px items-center mb-5">
-                      {renderMetaItems("desktop")}
+                  // One meta list for both breakpoints: stacked with the tag
+                  // beside it on mobile, horizontal row on desktop (where the
+                  // tag is the absolutely positioned one above). Rendering it
+                  // twice would double-mount AuthorDisplay and duplicate the
+                  // comments link for crawlers and assistive tech.
+                  <div className="flex items-start justify-between gap-3 mb-5">
+                    <ul className="flex flex-col md:flex-row md:flex-wrap gap-2 md:gap-x-25px md:gap-y-10px md:items-center min-w-0">
+                      {renderMetaItems("meta")}
                     </ul>
-                  </>
+                    {category ? (
+                      <Link
+                        href={`/blogs?category=${makePath(category)}`}
+                        className={`${categoryPillClass} shrink-0 md:hidden`}
+                      >
+                        {category}
+                      </Link>
+                    ) : null}
+                  </div>
                 ) : (
                   <ul className="flex flex-wrap gap-x-15px gap-y-10px md:gap-25px items-center mb-5">
                     {renderMetaItems("cover")}

--- a/src/components/shared/others/Paginations.js
+++ b/src/components/shared/others/Paginations.js
@@ -1,6 +1,10 @@
 "use client";
 import Link from "next/link";
-import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+// Paginations is prerendered on the server, where useLayoutEffect warns.
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 // Circular page / arrow cells.
 const CELL =
@@ -11,12 +15,23 @@ const ACTIVE =
   "bg-primary-color text-white-color border-primary-color shadow-sm";
 const DISABLED = "opacity-40 pointer-events-none";
 
-const ITEM_PX = 36;
-const GAP_PX = 6;
+// Cell/gap sizes must mirror what CELL and the <ul> actually render, or the
+// slot budget overshoots the bar and the trailing arrow gets clipped.
+// Tailwind's `sm` breakpoint is 576px in this theme.
+const SM_BREAKPOINT_PX = 576;
+const ITEM_PX_XS = 32; // size-8
+const ITEM_PX_SM = 36; // sm:size-9
+const GAP_PX_XS = 6; // gap-1.5
+const GAP_PX_SM = 8; // sm:gap-2
 const SIDE_CONTROLS = 2;
-const BAR_PAD_PX = 16;
 // Total width for all ellipsis blocks combined (~20–30% of the bar).
 const DOTS_TOTAL_RATIO = 0.25;
+// An ellipsis block narrower than this reads as a smudge, not a gap.
+const MIN_DOTS_PX = 20;
+const MAX_DOTS_PX = 64;
+// buildPages needs 5 slots to lay out start + middle + end; below the width
+// where 5 cells plus both arrows fit, fall back to a compact "n / N" bar.
+const MIN_SLOTS = 5;
 
 /** Trailing pages stay compact; extra width grows the start cluster. */
 function endCountForWidth(width) {
@@ -25,17 +40,30 @@ function endCountForWidth(width) {
   return 3;
 }
 
-/** Page-number cells that fit (prev/next + ~25% reserved for dots). */
-function pageSlotsForWidth(width) {
-  if (!width) return 9;
-  const arrowSpace = SIDE_CONTROLS * (ITEM_PX + GAP_PX);
-  const dotsReserve = width * DOTS_TOTAL_RATIO;
-  const usable = Math.max(
-    0,
-    width - arrowSpace - BAR_PAD_PX - dotsReserve
+/** Width every cell in a full bar occupies: n cells sit between n+1 gaps. */
+function widthForCells(cellCount, item, gap) {
+  return cellCount * item + (cellCount + 1) * gap;
+}
+
+/** Page-number cells that fit (prev/next + up to ~25% reserved for dots). */
+function pageSlotsForWidth(width, item, gap) {
+  // Server render has no measurement yet; the smallest bar is the safe guess.
+  if (!width) return MIN_SLOTS;
+  const arrowSpace = SIDE_CONTROLS * item;
+  const dotsReserve = Math.min(
+    Math.max(width * DOTS_TOTAL_RATIO, MIN_DOTS_PX * 2),
+    MAX_DOTS_PX * 2
   );
-  const slots = Math.floor((usable + GAP_PX) / (ITEM_PX + GAP_PX));
-  return Math.max(5, slots);
+  const usable = Math.max(0, width - arrowSpace - dotsReserve);
+  const slots = Math.floor((usable - gap) / (item + gap));
+  return Math.max(MIN_SLOTS, slots);
+}
+
+/** True when even the minimum full bar would overflow and clip the arrows. */
+function needsCompactBar(width, item, gap) {
+  if (!width) return false;
+  const cells = MIN_SLOTS + SIDE_CONTROLS;
+  return widthForCells(cells, item, gap) + MIN_DOTS_PX * 2 > width;
 }
 
 function pageNodes(from, to) {
@@ -141,8 +169,11 @@ const Paginations = ({ paginationDetails }) => {
   // Measure the constrained parent, not the list content (avoids overflow feedback loop).
   const measureRef = useRef(null);
   const [barWidth, setBarWidth] = useState(0);
+  // Cell and gap sizes come from the viewport breakpoint, not the bar width:
+  // a narrow bar on a wide screen still renders the larger `sm` cells.
+  const [isSmUp, setIsSmUp] = useState(false);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const el = measureRef.current;
     if (!el || typeof ResizeObserver === "undefined") return undefined;
     const measure = () => setBarWidth(el.getBoundingClientRect().width);
@@ -152,11 +183,25 @@ const Paginations = ({ paginationDetails }) => {
     return () => ro.disconnect();
   }, []);
 
+  useIsomorphicLayoutEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+    const mq = window.matchMedia(`(min-width: ${SM_BREAKPOINT_PX}px)`);
+    const sync = () => setIsSmUp(mq.matches);
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+
+  const itemPx = isSmUp ? ITEM_PX_SM : ITEM_PX_XS;
+  const gapPx = isSmUp ? GAP_PX_SM : GAP_PX_XS;
+  const compact = needsCompactBar(barWidth, itemPx, gapPx);
+
   const pages = useMemo(() => {
-    const slots = pageSlotsForWidth(barWidth);
+    if (compact) return [];
+    const slots = pageSlotsForWidth(barWidth, itemPx, gapPx);
     const endCount = endCountForWidth(barWidth);
     return buildPages(currentpage, totalPages, slots, endCount);
-  }, [barWidth, currentpage, totalPages]);
+  }, [compact, barWidth, itemPx, gapPx, currentpage, totalPages]);
 
   if (!totalPages || totalPages <= 1) return null;
 
@@ -164,11 +209,52 @@ const Paginations = ({ paginationDetails }) => {
   const isLast = currentpage >= totalPages - 1;
   const gapCount = pages.filter((item) => item.type === "gap").length;
   const hasDots = gapCount > 0;
-  // Split the 25% dots budget across however many ellipsis blocks are shown.
-  const gapWidthPct =
-    gapCount > 0 ? (DOTS_TOTAL_RATIO * 100) / gapCount : 0;
+  // Dots absorb whatever the fixed-width cells leave over, within sane bounds,
+  // so the bar can never total more than its container.
+  const cellsWidth = widthForCells(
+    pages.length - gapCount + SIDE_CONTROLS,
+    itemPx,
+    gapPx
+  );
   const gapWidthPx =
-    gapCount > 0 && barWidth > 0 ? (barWidth * gapWidthPct) / 100 : 0;
+    gapCount > 0 && barWidth > 0
+      ? Math.min(
+          MAX_DOTS_PX,
+          Math.max(MIN_DOTS_PX, (barWidth - cellsWidth) / gapCount)
+        )
+      : 0;
+
+  const pageItems = pages.map((item) =>
+    item.type === "gap" ? (
+      <li
+        key={item.key}
+        className="inline-flex items-center justify-center min-w-0"
+        style={{
+          flex: `1 1 ${MIN_DOTS_PX}px`,
+          minWidth: MIN_DOTS_PX,
+          maxWidth: MAX_DOTS_PX,
+        }}
+        aria-hidden="true"
+      >
+        <DotsGap widthPx={gapWidthPx} />
+      </li>
+    ) : (
+      <li
+        key={item.value}
+        className={`shrink-0 ${item.value === currentpage ? "active" : ""}`}
+      >
+        <Link
+          href="#blogs"
+          aria-label={`Page ${item.value + 1}`}
+          aria-current={item.value === currentpage ? "page" : undefined}
+          onClick={(e) => handleCurrentPage(e, item.value)}
+          className={`${CELL} ${item.value === currentpage ? ACTIVE : IDLE}`}
+        >
+          {item.value + 1}
+        </Link>
+      </li>
+    )
+  );
 
   return (
     <nav
@@ -200,39 +286,15 @@ const Paginations = ({ paginationDetails }) => {
           </Link>
         </li>
 
-        {pages.map((item) =>
-          item.type === "gap" ? (
-            <li
-              key={item.key}
-              className="shrink-0 inline-flex items-center justify-center min-w-0"
-              style={{
-                width: `${gapWidthPct}%`,
-                flex: `0 0 ${gapWidthPct}%`,
-              }}
-              aria-hidden="true"
-            >
-              <DotsGap widthPx={gapWidthPx} />
-            </li>
-          ) : (
-            <li
-              key={item.value}
-              className={`shrink-0 ${
-                item.value === currentpage ? "active" : ""
-              }`}
-            >
-              <Link
-                href="#blogs"
-                aria-label={`Page ${item.value + 1}`}
-                aria-current={item.value === currentpage ? "page" : undefined}
-                onClick={(e) => handleCurrentPage(e, item.value)}
-                className={`${CELL} ${
-                  item.value === currentpage ? ACTIVE : IDLE
-                }`}
-              >
-                {item.value + 1}
-              </Link>
-            </li>
-          )
+        {compact ? (
+          <li
+            className="shrink min-w-0 px-2 text-sm font-medium text-primary-color-light dark:text-white-color whitespace-nowrap"
+            aria-current="page"
+          >
+            {currentpage + 1} / {totalPages}
+          </li>
+        ) : (
+          pageItems
         )}
 
         <li className="shrink-0">

--- a/src/components/shared/others/Paginations.js
+++ b/src/components/shared/others/Paginations.js
@@ -1,50 +1,188 @@
 "use client";
 import Link from "next/link";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 
-// Base circle for every control (page number, arrow, ellipsis).
-const CIRCLE =
-  "w-9 h-9 sm:w-10 sm:h-10 text-sm sm:text-base font-medium rounded-full inline-flex justify-center items-center transition-all duration-300";
+// Circular page / arrow cells.
+const CELL =
+  "size-8 sm:size-9 text-sm font-medium rounded-full inline-flex justify-center items-center border transition-all duration-300 select-none shrink-0";
 const IDLE =
-  "bg-seondary-color dark:bg-transparent text-white-color dark:text-white-color hover:text-white-color hover:bg-primary-color dark:hover:bg-primary-color";
-const ACTIVE = "bg-primary-color text-white-color";
+  "bg-transparent text-primary-color-light dark:text-white-color border-transparent hover:text-primary-color";
+const ACTIVE =
+  "bg-primary-color text-white-color border-primary-color shadow-sm";
 const DISABLED = "opacity-40 pointer-events-none";
 
-// Compact page window: always first + last, the current page and its
-// neighbours, and an ellipsis wherever there's a gap. Pages are 0-indexed.
-const buildPages = (current, total) => {
-  const last = total - 1;
-  const shown = new Set([0, last]);
-  for (let p = current - 1; p <= current + 1; p++) {
-    if (p >= 0 && p <= last) shown.add(p);
+const ITEM_PX = 36;
+const GAP_PX = 6;
+const SIDE_CONTROLS = 2;
+const BAR_PAD_PX = 16;
+// Total width for all ellipsis blocks combined (~20–30% of the bar).
+const DOTS_TOTAL_RATIO = 0.25;
+
+/** Trailing pages stay compact; extra width grows the start cluster. */
+function endCountForWidth(width) {
+  if (width < 400) return 1;
+  if (width < 900) return 2;
+  return 3;
+}
+
+/** Page-number cells that fit (prev/next + ~25% reserved for dots). */
+function pageSlotsForWidth(width) {
+  if (!width) return 9;
+  const arrowSpace = SIDE_CONTROLS * (ITEM_PX + GAP_PX);
+  const dotsReserve = width * DOTS_TOTAL_RATIO;
+  const usable = Math.max(
+    0,
+    width - arrowSpace - BAR_PAD_PX - dotsReserve
+  );
+  const slots = Math.floor((usable + GAP_PX) / (ITEM_PX + GAP_PX));
+  return Math.max(5, slots);
+}
+
+function pageNodes(from, to) {
+  const nodes = [];
+  for (let i = from; i <= to; i += 1) {
+    nodes.push({ type: "page", value: i });
   }
-  const sorted = [...shown].sort((a, b) => a - b);
-  const out = [];
-  sorted.forEach((page, i) => {
-    out.push({ type: "page", value: page });
-    if (i < sorted.length - 1 && sorted[i + 1] - page > 1) {
-      out.push({ type: "gap", key: `gap-${page}` });
-    }
-  });
-  return out;
-};
+  return nodes;
+}
+
+/**
+ * Ideal: 1 2 3 4 5 … 15 16 17 … 40 41
+ * Middle = prev / current / next.
+ * Extra width loads more starting page numbers (not wider dots).
+ */
+function buildPages(current, total, maxSlots, endTarget) {
+  if (total <= 0) return [];
+  if (total <= maxSlots) {
+    return pageNodes(0, total - 1);
+  }
+
+  const last = total - 1;
+  const midBudget = 3;
+
+  let endBound = Math.max(1, Math.min(endTarget, maxSlots - midBudget - 1));
+  // All remaining slots go to the start cluster.
+  let startBound = Math.max(1, maxSlots - midBudget - endBound);
+
+  const startEnd = startBound - 1;
+  const endStart = last - endBound + 1;
+
+  let midStart = current - 1;
+  let midEnd = current + 1;
+  if (midStart < 0) {
+    midStart = 0;
+    midEnd = Math.min(last, midBudget - 1);
+  }
+  if (midEnd > last) {
+    midEnd = last;
+    midStart = Math.max(0, last - midBudget + 1);
+  }
+
+  // Near start → absorb middle into the leading run (one right gap).
+  if (midStart <= startEnd + 1) {
+    const leadEnd = Math.min(endStart - 2, Math.max(midEnd, maxSlots - endBound - 1));
+    return [
+      ...pageNodes(0, leadEnd),
+      { type: "gap", key: "gap-right" },
+      ...pageNodes(endStart, last),
+    ];
+  }
+
+  // Near end → absorb middle into the trailing run (one left gap).
+  if (midEnd >= endStart - 1) {
+    const trailStart = Math.max(
+      startEnd + 2,
+      Math.min(midStart, last - (maxSlots - startBound) + 1)
+    );
+    return [
+      ...pageNodes(0, startEnd),
+      { type: "gap", key: "gap-left" },
+      ...pageNodes(trailStart, last),
+    ];
+  }
+
+  // Middle: 1 2 3 4 5 … 10 11 12 … 40 41
+  return [
+    ...pageNodes(0, startEnd),
+    { type: "gap", key: "gap-left" },
+    ...pageNodes(midStart, midEnd),
+    { type: "gap", key: "gap-right" },
+    ...pageNodes(endStart, last),
+  ];
+}
+
+function dotsCountForWidth(widthPx) {
+  // Keep clear space between dots so they never merge into a solid line.
+  const DOT_PX = 4;
+  const MIN_GAP_PX = 8;
+  const PAD_PX = 8;
+  if (!widthPx || widthPx < DOT_PX + PAD_PX) return 3;
+  const usable = Math.max(DOT_PX, widthPx - PAD_PX);
+  return Math.max(3, Math.min(10, Math.floor((usable + MIN_GAP_PX) / (DOT_PX + MIN_GAP_PX))));
+}
+
+function DotsGap({ widthPx }) {
+  const count = dotsCountForWidth(widthPx);
+  const dots = Array.from({ length: count }, (_, i) => (
+    <span
+      key={i}
+      className="size-1 shrink-0 rounded-full bg-[#cfcfcf] dark:bg-white-color/35"
+    />
+  ));
+  return (
+    <span className="flex items-center justify-between w-full min-w-0 px-1.5">
+      {dots}
+    </span>
+  );
+}
 
 const Paginations = ({ paginationDetails }) => {
   const { currentpage, totalPages, handleCurrentPage } = paginationDetails;
+  // Measure the constrained parent, not the list content (avoids overflow feedback loop).
+  const measureRef = useRef(null);
+  const [barWidth, setBarWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const el = measureRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return undefined;
+    const measure = () => setBarWidth(el.getBoundingClientRect().width);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const pages = useMemo(() => {
+    const slots = pageSlotsForWidth(barWidth);
+    const endCount = endCountForWidth(barWidth);
+    return buildPages(currentpage, totalPages, slots, endCount);
+  }, [barWidth, currentpage, totalPages]);
+
   if (!totalPages || totalPages <= 1) return null;
 
   const isFirst = currentpage <= 0;
   const isLast = currentpage >= totalPages - 1;
-  const pages = buildPages(currentpage, totalPages);
+  const gapCount = pages.filter((item) => item.type === "gap").length;
+  const hasDots = gapCount > 0;
+  // Split the 25% dots budget across however many ellipsis blocks are shown.
+  const gapWidthPct =
+    gapCount > 0 ? (DOTS_TOTAL_RATIO * 100) / gapCount : 0;
+  const gapWidthPx =
+    gapCount > 0 && barWidth > 0 ? (barWidth * gapWidthPct) / 100 : 0;
 
   return (
     <nav
+      ref={measureRef}
       aria-label="Blog pagination"
-      className="wow fadeInUp w-full"
+      className="wow fadeInUp w-full max-w-full min-w-0"
       data-wow-delay=".3s"
     >
-      <ul className="paginations flex flex-nowrap justify-between sm:justify-between items-center gap-2 sm:gap-3 w-full">
-        {/* previous */}
-        <li>
+      <ul
+        className={`paginations flex flex-nowrap items-center w-full max-w-full min-w-0 overflow-hidden gap-1.5 sm:gap-2 box-border ${
+          hasDots ? "" : "justify-center"
+        }`}
+      >
+        <li className="shrink-0">
           <Link
             href="#blogs"
             aria-label="Previous page"
@@ -56,27 +194,29 @@ const Paginations = ({ paginationDetails }) => {
               }
               handleCurrentPage(e, currentpage - 1);
             }}
-            className={`${CIRCLE} ${IDLE} ${isFirst ? DISABLED : ""}`}
+            className={`${CELL} ${IDLE} ${isFirst ? DISABLED : ""}`}
           >
-            <i className="fal fa-arrow-left"></i>
+            <i className="fal fa-chevron-left text-xs" />
           </Link>
         </li>
 
-        {/* page numbers (sm and up) */}
         {pages.map((item) =>
           item.type === "gap" ? (
-            <li key={item.key} className="hidden sm:inline-flex">
-              <span
-                aria-hidden="true"
-                className={`${CIRCLE} text-primary-color-light dark:text-white-color opacity-60`}
-              >
-                …
-              </span>
+            <li
+              key={item.key}
+              className="shrink-0 inline-flex items-center justify-center min-w-0"
+              style={{
+                width: `${gapWidthPct}%`,
+                flex: `0 0 ${gapWidthPct}%`,
+              }}
+              aria-hidden="true"
+            >
+              <DotsGap widthPx={gapWidthPx} />
             </li>
           ) : (
             <li
               key={item.value}
-              className={`hidden sm:inline-flex ${
+              className={`shrink-0 ${
                 item.value === currentpage ? "active" : ""
               }`}
             >
@@ -85,7 +225,7 @@ const Paginations = ({ paginationDetails }) => {
                 aria-label={`Page ${item.value + 1}`}
                 aria-current={item.value === currentpage ? "page" : undefined}
                 onClick={(e) => handleCurrentPage(e, item.value)}
-                className={`${CIRCLE} ${
+                className={`${CELL} ${
                   item.value === currentpage ? ACTIVE : IDLE
                 }`}
               >
@@ -95,15 +235,7 @@ const Paginations = ({ paginationDetails }) => {
           )
         )}
 
-        {/* compact indicator (below sm) */}
-        <li className="sm:hidden">
-          <span className="px-3 h-9 inline-flex items-center text-sm font-medium text-primary-color-light dark:text-white-color tabular-nums">
-            {currentpage + 1} / {totalPages}
-          </span>
-        </li>
-
-        {/* next */}
-        <li>
+        <li className="shrink-0">
           <Link
             href="#blogs"
             aria-label="Next page"
@@ -115,9 +247,9 @@ const Paginations = ({ paginationDetails }) => {
               }
               handleCurrentPage(e, currentpage + 1);
             }}
-            className={`${CIRCLE} ${IDLE} ${isLast ? DISABLED : ""}`}
+            className={`${CELL} ${IDLE} ${isLast ? DISABLED : ""}`}
           >
-            <i className="fal fa-arrow-right"></i>
+            <i className="fal fa-chevron-right text-xs" />
           </Link>
         </li>
       </ul>

--- a/src/components/shared/others/Paginations.js
+++ b/src/components/shared/others/Paginations.js
@@ -40,9 +40,10 @@ function endCountForWidth(width) {
   return 3;
 }
 
-/** Width every cell in a full bar occupies: n cells sit between n+1 gaps. */
+/** Packed flex row width: n cells with (n-1) gaps between them. */
 function widthForCells(cellCount, item, gap) {
-  return cellCount * item + (cellCount + 1) * gap;
+  if (cellCount <= 0) return 0;
+  return cellCount * item + Math.max(0, cellCount - 1) * gap;
 }
 
 /** Page-number cells that fit (prev/next + up to ~25% reserved for dots). */
@@ -59,9 +60,15 @@ function pageSlotsForWidth(width, item, gap) {
   return Math.max(MIN_SLOTS, slots);
 }
 
-/** True when even the minimum full bar would overflow and clip the arrows. */
-function needsCompactBar(width, item, gap) {
-  if (!width) return false;
+/**
+ * True when the page buttons would overflow and clip the arrows.
+ * Few-page lists skip the dots reserve so they stay as real buttons.
+ */
+function needsCompactBar(width, item, gap, totalPages) {
+  if (!width || !totalPages) return false;
+  if (totalPages <= MIN_SLOTS) {
+    return widthForCells(totalPages + SIDE_CONTROLS, item, gap) > width;
+  }
   const cells = MIN_SLOTS + SIDE_CONTROLS;
   return widthForCells(cells, item, gap) + MIN_DOTS_PX * 2 > width;
 }
@@ -194,7 +201,7 @@ const Paginations = ({ paginationDetails }) => {
 
   const itemPx = isSmUp ? ITEM_PX_SM : ITEM_PX_XS;
   const gapPx = isSmUp ? GAP_PX_SM : GAP_PX_XS;
-  const compact = needsCompactBar(barWidth, itemPx, gapPx);
+  const compact = needsCompactBar(barWidth, itemPx, gapPx, totalPages);
 
   const pages = useMemo(() => {
     if (compact) return [];

--- a/src/components/shared/sidebar/BlogSidebar.js
+++ b/src/components/shared/sidebar/BlogSidebar.js
@@ -3,12 +3,17 @@ import BlogSearchWidget from "./widgets/BlogSearchWidget";
 import PopularTagsNebula from "./widgets/PopularTagsNebula";
 import RecentBlogWidget from "./widgets/RecentBlogWidget";
 
-const BlogSidebar = () => {
+/**
+ * `mobileSearchElsewhere` is set by the blog list, which renders its own search
+ * above the results on small screens. Everywhere else (blog details) the
+ * sidebar keeps the search box at every breakpoint.
+ */
+const BlogSidebar = ({ mobileSearchElsewhere = false }) => {
   return (
     <div className="sidebar order-3 lg:order-2 lg:col-start-9 lg:col-span-4 pt-10 lg:pt-0 mt-60px lg:mt-0 border-t border-gray-color-3 lg:border-none">
       <div className="flex flex-col gap-30px">
         {/* Desktop/right column: search stays with the sidebar */}
-        <div className="hidden lg:block">
+        <div className={mobileSearchElsewhere ? "hidden lg:block" : ""}>
           <BlogSearchWidget />
         </div>
         <BlogCategoriesWidget />

--- a/src/components/shared/sidebar/BlogSidebar.js
+++ b/src/components/shared/sidebar/BlogSidebar.js
@@ -1,83 +1,18 @@
-"use client";
-import Image from "next/image";
-import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useRef, useState } from "react";
 import BlogCategoriesWidget from "./widgets/BlogCategoriesWidget";
+import BlogSearchWidget from "./widgets/BlogSearchWidget";
 import PopularTagsNebula from "./widgets/PopularTagsNebula";
 import RecentBlogWidget from "./widgets/RecentBlogWidget";
-import makePath from "@/libs/makePath";
-import makeText from "@/libs/makeText";
 
 const BlogSidebar = () => {
-  const router = useRouter();
-  // Seed the box from the URL so a shared/reloaded ?search= link stays in sync.
-  const initialSearch = useSearchParams()?.get("search");
-  const [searchTerm, setSearchTerm] = useState(
-    initialSearch ? makeText(initialSearch) : ""
-  );
-  const debounceRef = useRef(null);
-
-  // Live search: the /blogs list filters purely client-side off the ?search=
-  // query param, so we just keep the URL in step with the box as the user
-  // types (and as they delete). replace() keeps history from filling up with a
-  // stop per keystroke.
-  const applySearch = (value) => {
-    router.replace(
-      value.trim() ? `/blogs?search=${makePath(value)}` : "/blogs"
-    );
-  };
-
-  const handleChange = (e) => {
-    const value = e.target.value;
-    setSearchTerm(value);
-    clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => applySearch(value), 250);
-  };
-
-  const handleSearch = (e) => {
-    e.preventDefault();
-    // Submitting applies immediately (skip the debounce).
-    clearTimeout(debounceRef.current);
-    applySearch(searchTerm);
-  };
-
   return (
-    <div className="sidebar lg:col-start-9 lg:col-span-4 pt-10 lg:pt-0 mt-60px lg:mt-0 border-t border-gray-color-3 lg:border-none">
+    <div className="sidebar order-3 lg:order-2 lg:col-start-9 lg:col-span-4 pt-10 lg:pt-0 mt-60px lg:mt-0 border-t border-gray-color-3 lg:border-none">
       <div className="flex flex-col gap-30px">
-        {/* <!-- search --> */}
-        <div
-          className="px-15px md:px-25px py-30px bg-cream-light-color dark:bg-primary-color-light rounded-lg wow fadeInUp"
-          data-wow-delay=".3s"
-        >
-          <form onSubmit={handleSearch}>
-            <div className="flex">
-              {/* <!-- search input --> */}
-              <div className="flex-grow">
-                <input
-                  type="search"
-                  value={searchTerm}
-                  onChange={handleChange}
-                  placeholder="Search blogs & categories..."
-                  className="text-white-color w-full pl-5 py-4 border border-gray-color-3 bg-cream-light-color dark:bg-black-color focus:border-primary-color rounded-l-lg outline-none focus:outline-none transition-all duration-300 placeholder:text-gray-color leading-1"
-                />
-              </div>
-              <div className="min-h-full">
-                <button
-                  type="submit"
-                  className="w-60px h-full bg-primary-color hover:bg-seondary-color rounded-r-lg text-white-color text-xl inline-flex items-center justify-center transition-all duration-500"
-                >
-                  <i className="fa-light fa-magnifying-glass"></i>
-                </button>
-              </div>
-            </div>
-          </form>
+        {/* Desktop/right column: search stays with the sidebar */}
+        <div className="hidden lg:block">
+          <BlogSearchWidget />
         </div>
-        {/* <!-- categories --> */}
         <BlogCategoriesWidget />
-        {/* <!-- recent blogs--> */}
         <RecentBlogWidget />
-        {/* <!-- popular topics --> */}
         <PopularTagsNebula />
       </div>
     </div>

--- a/src/components/shared/sidebar/widgets/BlogSearchWidget.js
+++ b/src/components/shared/sidebar/widgets/BlogSearchWidget.js
@@ -1,0 +1,75 @@
+"use client";
+import makePath from "@/libs/makePath";
+import makeText from "@/libs/makeText";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+const BlogSearchWidget = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [searchTerm, setSearchTerm] = useState(() => {
+    const initialSearch = searchParams?.get("search");
+    return initialSearch ? makeText(initialSearch) : "";
+  });
+  const debounceRef = useRef(null);
+
+  // Keep both mobile/desktop instances in sync with the URL.
+  useEffect(() => {
+    const q = searchParams?.get("search");
+    setSearchTerm(q ? makeText(q) : "");
+  }, [searchParams]);
+
+  // Live search keeps ?search= in sync; new search resets ?page= to 1.
+  const applySearch = (value) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value.trim()) params.set("search", makePath(value));
+    else params.delete("search");
+    params.delete("page");
+    const qs = params.toString();
+    router.replace(qs ? `/blogs?${qs}` : "/blogs");
+  };
+
+  const handleChange = (e) => {
+    const value = e.target.value;
+    setSearchTerm(value);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => applySearch(value), 250);
+  };
+
+  const handleSearch = (e) => {
+    e.preventDefault();
+    clearTimeout(debounceRef.current);
+    applySearch(searchTerm);
+  };
+
+  return (
+    <div
+      className="px-15px md:px-25px py-30px bg-cream-light-color dark:bg-primary-color-light rounded-lg wow fadeInUp"
+      data-wow-delay=".3s"
+    >
+      <form onSubmit={handleSearch}>
+        <div className="flex">
+          <div className="flex-grow">
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={handleChange}
+              placeholder="Search blogs & categories..."
+              className="text-white-color w-full pl-5 py-4 border border-gray-color-3 bg-cream-light-color dark:bg-black-color focus:border-primary-color rounded-l-lg outline-none focus:outline-none transition-all duration-300 placeholder:text-gray-color leading-1"
+            />
+          </div>
+          <div className="min-h-full">
+            <button
+              type="submit"
+              className="w-60px h-full bg-primary-color hover:bg-seondary-color rounded-r-lg text-white-color text-xl inline-flex items-center justify-center transition-all duration-500"
+            >
+              <i className="fa-light fa-magnifying-glass"></i>
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default BlogSearchWidget;

--- a/src/components/shared/sidebar/widgets/BlogSearchWidget.js
+++ b/src/components/shared/sidebar/widgets/BlogSearchWidget.js
@@ -12,17 +12,26 @@ const BlogSearchWidget = () => {
     return initialSearch ? makeText(initialSearch) : "";
   });
   const debounceRef = useRef(null);
+  // Last value this instance pushed to the URL. makePath is lossy (lowercases,
+  // maps "/" and "&" to spaces), so echoing our own write back into the input
+  // would rewrite what the user typed and jump the caret to the end.
+  const lastPushedRef = useRef(searchParams?.get("search") || "");
 
-  // Keep both mobile/desktop instances in sync with the URL.
+  // Sync with genuinely external URL changes only: the other instance, history
+  // navigation, or a category link.
   useEffect(() => {
-    const q = searchParams?.get("search");
+    const q = searchParams?.get("search") || "";
+    if (q === lastPushedRef.current) return;
+    lastPushedRef.current = q;
     setSearchTerm(q ? makeText(q) : "");
   }, [searchParams]);
 
   // Live search keeps ?search= in sync; new search resets ?page= to 1.
   const applySearch = (value) => {
     const params = new URLSearchParams(searchParams.toString());
-    if (value.trim()) params.set("search", makePath(value));
+    const next = value.trim() ? makePath(value) : "";
+    lastPushedRef.current = next;
+    if (next) params.set("search", next);
     else params.delete("search");
     params.delete("page");
     const qs = params.toString();

--- a/src/components/shared/sidebar/widgets/BlogSearchWidget.js
+++ b/src/components/shared/sidebar/widgets/BlogSearchWidget.js
@@ -22,6 +22,9 @@ const BlogSearchWidget = () => {
   useEffect(() => {
     const q = searchParams?.get("search") || "";
     if (q === lastPushedRef.current) return;
+    // Cancel an in-flight debounce so a stale applySearch can't overwrite
+    // a just-applied ?category= / cleared search from another control.
+    clearTimeout(debounceRef.current);
     lastPushedRef.current = q;
     setSearchTerm(q ? makeText(q) : "");
   }, [searchParams]);
@@ -35,7 +38,7 @@ const BlogSearchWidget = () => {
     else params.delete("search");
     params.delete("page");
     const qs = params.toString();
-    router.replace(qs ? `/blogs?${qs}` : "/blogs");
+    router.replace(qs ? `/blogs?${qs}` : "/blogs", { scroll: false });
   };
 
   const handleChange = (e) => {

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -7,7 +7,12 @@ import { useCallback, useEffect, useMemo } from "react";
  * Blog list pagination synced to the URL via `?page=` (1-based).
  * Reload / share keeps the same page. Page 1 omits the param.
  */
-const usePagination = (filteredItems, currentLimit, pagiItemsLengthPerView) => {
+const usePagination = (
+  filteredItems,
+  currentLimit,
+  pagiItemsLengthPerView,
+  scrollTargetId = "blogs"
+) => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -25,6 +30,14 @@ const usePagination = (filteredItems, currentLimit, pagiItemsLengthPerView) => {
     return index;
   }, [searchParams, totalPages]);
 
+  const dropPageFromUrl = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (!params.has("page")) return;
+    params.delete("page");
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [router, pathname, searchParams]);
+
   const setPageInUrl = useCallback(
     (pageIndex) => {
       const params = new URLSearchParams(searchParams.toString());
@@ -37,15 +50,24 @@ const usePagination = (filteredItems, currentLimit, pagiItemsLengthPerView) => {
     [router, pathname, searchParams]
   );
 
-  // If filters shrink the result set, clamp an out-of-range ?page= in the URL.
+  // Keep ?page= honest: drop it when there are no results, and clamp or discard
+  // values that filters made out of range or that were never a number at all.
   useEffect(() => {
-    if (totalPages <= 0) return;
-    const raw = parseInt(searchParams.get("page") || "1", 10);
-    if (!Number.isFinite(raw)) return;
+    const param = searchParams.get("page");
+    if (param === null) return;
+    if (totalPages <= 0) {
+      dropPageFromUrl();
+      return;
+    }
+    const raw = parseInt(param, 10);
+    if (!Number.isFinite(raw)) {
+      dropPageFromUrl();
+      return;
+    }
     if (raw < 1 || raw > totalPages) {
       setPageInUrl(Math.min(Math.max(raw - 1, 0), totalPages - 1));
     }
-  }, [totalPages, searchParams, setPageInUrl]);
+  }, [totalPages, searchParams, setPageInUrl, dropPageFromUrl]);
 
   const skip = limit * currentpage;
   const currentItems = filteredItems?.slice(skip, skip + limit);
@@ -56,8 +78,15 @@ const usePagination = (filteredItems, currentLimit, pagiItemsLengthPerView) => {
   );
 
   const handleCurrentPage = (e, id) => {
+    // The links carry href="#blogs" only as a no-JS fallback; we suppress the
+    // hash navigation (it would stack history entries) and scroll explicitly,
+    // otherwise the viewport stays parked on the pagination bar.
     e?.preventDefault?.();
     setPageInUrl(id);
+    if (typeof document === "undefined") return;
+    document
+      .getElementById(scrollTargetId)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
   let showMore = false;

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -83,10 +83,17 @@ const usePagination = (
     // otherwise the viewport stays parked on the pagination bar.
     e?.preventDefault?.();
     setPageInUrl(id);
-    if (typeof document === "undefined") return;
-    document
-      .getElementById(scrollTargetId)
-      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (typeof document === "undefined" || typeof window === "undefined") {
+      return;
+    }
+    const target = document.getElementById(scrollTargetId);
+    if (!target) return;
+    // Offset for the sticky header so the section title isn't covered.
+    const header = document.querySelector(".header-area.header-sticky");
+    const headerOffset = header?.getBoundingClientRect().height ?? 0;
+    const top =
+      target.getBoundingClientRect().top + window.scrollY - headerOffset - 12;
+    window.scrollTo({ top: Math.max(0, top), behavior: "smooth" });
   };
 
   let showMore = false;

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -1,25 +1,65 @@
 "use client";
 
-import { useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo } from "react";
 
+/**
+ * Blog list pagination synced to the URL via `?page=` (1-based).
+ * Reload / share keeps the same page. Page 1 omits the param.
+ */
 const usePagination = (filteredItems, currentLimit, pagiItemsLengthPerView) => {
-  // stats
-  const [currentpage, setCurrentpage] = useState(0);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  // pagination related
   const limit = currentLimit ? currentLimit : 6;
+  const totalItems = filteredItems?.length ?? 0;
+  const totalPages = Math.ceil(totalItems / limit) || 0;
+
+  const currentpage = useMemo(() => {
+    if (totalPages <= 0) return 0;
+    const raw = parseInt(searchParams.get("page") || "1", 10);
+    const index = Number.isFinite(raw) ? raw - 1 : 0;
+    if (index < 0) return 0;
+    if (index > totalPages - 1) return totalPages - 1;
+    return index;
+  }, [searchParams, totalPages]);
+
+  const setPageInUrl = useCallback(
+    (pageIndex) => {
+      const params = new URLSearchParams(searchParams.toString());
+      const pageNum = Math.max(1, pageIndex + 1);
+      if (pageNum <= 1) params.delete("page");
+      else params.set("page", String(pageNum));
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [router, pathname, searchParams]
+  );
+
+  // If filters shrink the result set, clamp an out-of-range ?page= in the URL.
+  useEffect(() => {
+    if (totalPages <= 0) return;
+    const raw = parseInt(searchParams.get("page") || "1", 10);
+    if (!Number.isFinite(raw)) return;
+    if (raw < 1 || raw > totalPages) {
+      setPageInUrl(Math.min(Math.max(raw - 1, 0), totalPages - 1));
+    }
+  }, [totalPages, searchParams, setPageInUrl]);
+
   const skip = limit * currentpage;
   const currentItems = filteredItems?.slice(skip, skip + limit);
-  const totalItems = filteredItems?.length;
-  const totalCurrentItems = currentItems?.length;
-  const totalPages = Math.ceil(totalItems / limit);
-  const paginationItemsUnmodified = [...Array(totalPages)];
-  const paginationItems = paginationItemsUnmodified?.map((it, idx) => idx);
+  const totalCurrentItems = currentItems?.length ?? 0;
+  const paginationItems = useMemo(
+    () => Array.from({ length: totalPages }, (_, idx) => idx),
+    [totalPages]
+  );
 
-  // hande currentpage
   const handleCurrentPage = (e, id) => {
-    setCurrentpage(id);
+    e?.preventDefault?.();
+    setPageInUrl(id);
   };
+
   let showMore = false;
   let currentPaginationItems = paginationItems;
   if (totalPages > pagiItemsLengthPerView) {
@@ -28,18 +68,18 @@ const usePagination = (filteredItems, currentLimit, pagiItemsLengthPerView) => {
       currentpage >= totalPages - (pagiItemsLengthPerView < 6 ? 2 : 3)
         ? -(pagiItemsLengthPerView - 2)
         : currentpage < pagiItemsLengthPerView - 3
-        ? 0
-        : showMore === "left"
-        ? currentpage - 1
-        : currentpage - (pagiItemsLengthPerView - 4);
+          ? 0
+          : showMore === "left"
+            ? currentpage - 1
+            : currentpage - (pagiItemsLengthPerView - 4);
     const sliceEndPoind =
       currentpage >= totalPages - (pagiItemsLengthPerView < 6 ? 2 : 3)
         ? totalPages
         : currentpage < pagiItemsLengthPerView - 3
-        ? pagiItemsLengthPerView - 2
-        : showMore === "left"
-        ? currentpage + (pagiItemsLengthPerView - 3)
-        : currentpage + 2;
+          ? pagiItemsLengthPerView - 2
+          : showMore === "left"
+            ? currentpage + (pagiItemsLengthPerView - 3)
+            : currentpage + 2;
     currentPaginationItems = paginationItems?.slice(
       sliceStartPoint,
       sliceEndPoind
@@ -50,13 +90,13 @@ const usePagination = (filteredItems, currentLimit, pagiItemsLengthPerView) => {
     currentItems,
     totalItems,
     currentpage,
-    setCurrentpage,
+    setCurrentpage: setPageInUrl,
     paginationItems,
     currentPaginationItems,
     showMore,
     totalPages,
     handleCurrentPage,
-    firstItem: skip + 1,
+    firstItem: totalItems ? skip + 1 : 0,
     lastItem:
       totalItems < limit
         ? totalItems


### PR DESCRIPTION
## Summary
- Rebuild blog pagination with a responsive start / current / end window, compact dots, and `?page=` URL persistence (reload/share keeps the page)
- Put search above the post list on mobile only; keep the full sidebar (search + widgets) in the right column on desktop
- Fix no-cover cards: mobile stacks date/author on the left with the tag on the right; desktop keeps the previous horizontal meta layout
- CTA copy stays as “View Full Post”

## Test plan
- [ ] Open blog list, change pages — URL updates (`?page=N`), reload stays on that page
- [ ] Resize narrow → wide: pagination shows start pages + prev/current/next + end pages; dots stay spaced on mobile
- [ ] Mobile: search appears above posts; categories/recent/tags appear below
- [ ] Desktop: search + sidebar remain in the right column
- [ ] Card without cover: mobile stacked meta + tag; desktop previous layout
- [ ] Card with cover: tag still overlays the image


Made with [Cursor](https://cursor.com)