### PR TITLE
fix(content): keep absolute image URLs intact when mapping CMS content

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "export": "next build",
     "deploy:build": "npm run build && npm run export",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test \"src/libs/__tests__/*.test.mjs\""
   },
   "dependencies": {
     "@vercel/analytics": "^1.5.0",

--- a/src/libs/__tests__/contentMapping.test.mjs
+++ b/src/libs/__tests__/contentMapping.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  RAW_BASE,
+  mapSkills,
+  mapPortfolio,
+  resolveFileUrl,
+} from "../contentMapping.js";
+
+const REMOTE_ICON = "https://cdn.simpleicons.org/vuedotjs/4FC08D.png";
+
+const skillsWith = (icon) => ({
+  categories: [{ skills: [{ name: "Vue", icon, proficiency: 70 }] }],
+});
+
+test("repo-relative skill icons resolve against the admin host", () => {
+  const [skill] = mapSkills(skillsWith("/images/skills/react.png"));
+  assert.equal(skill.img, `${RAW_BASE}/images/skills/react.png`);
+});
+
+test("absolute skill icon URLs are left untouched", () => {
+  const [skill] = mapSkills(skillsWith(REMOTE_ICON));
+  assert.equal(skill.img, REMOTE_ICON);
+});
+
+test("protocol-relative skill icon URLs are left untouched", () => {
+  const [skill] = mapSkills(skillsWith("//cdn.simpleicons.org/react.png"));
+  assert.equal(skill.img, "//cdn.simpleicons.org/react.png");
+});
+
+test("a missing skill icon stays empty rather than becoming the bare host", () => {
+  const [skill] = mapSkills(skillsWith(""));
+  assert.equal(skill.img, "");
+});
+
+test("absolute project cover URLs are left untouched", () => {
+  const projects = mapPortfolio(
+    {
+      items: [
+        {
+          slug: "demo",
+          title: "Demo",
+          category: "Web",
+          image: REMOTE_ICON,
+          technologies: [],
+          sections: [],
+        },
+      ],
+    },
+    { name: "Mohan", headline: "Engineer", avatar: REMOTE_ICON }
+  );
+  assert.equal(projects[0].img, REMOTE_ICON);
+});
+
+test("resolveFileUrl already passes absolute URLs through", () => {
+  assert.equal(resolveFileUrl("https://example.com/cv.pdf"), "https://example.com/cv.pdf");
+  assert.equal(resolveFileUrl("/files/cv.pdf"), `${RAW_BASE}/files/cv.pdf`);
+});

--- a/src/libs/contentMapping.js
+++ b/src/libs/contentMapping.js
@@ -14,7 +14,17 @@ export const FILES_BASE = "https://admin.devmohan.in";
 export const resolveFileUrl = (p) =>
   p && p.startsWith("/") ? `${FILES_BASE}${p}` : p || "";
 
-const img = (p) => (p ? `${RAW_BASE}${p}` : "");
+// Same contract as resolveFileUrl: repo-relative paths from the admin's image
+// widget resolve against the admin host, while a value the editor pasted as an
+// absolute (or protocol-relative) URL is already complete and passes through.
+// Prefixing those produced "https://admin.devmohan.inhttps://..." — a broken
+// image everywhere icons, logos, avatars and covers are rendered.
+const isAbsoluteUrl = (p) => /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(p);
+
+const img = (p) => {
+  if (!p) return "";
+  return isAbsoluteUrl(p) ? p : `${RAW_BASE}${p}`;
+};
 
 const MONTH_NAMES = {
   "01": "Jan", "02": "Feb", "03": "Mar", "04": "Apr", "05": "May", "06": "Jun",


### PR DESCRIPTION
## Problem

Skill icons — and every other CMS image field — render as broken images when the value is a URL the editor pasted rather than a file uploaded through the admin.

`src/libs/contentMapping.js` prefixed **every** image value with `RAW_BASE`:

```js
const img = (p) => (p ? `${RAW_BASE}${p}` : "");
```

So `https://cdn.simpleicons.org/vuedotjs/4FC08D.png` became:

```
https://admin.devmohan.inhttps://cdn.simpleicons.org/vuedotjs/4FC08D.png
```

The sibling helper `resolveFileUrl`, two lines above, already had the right contract — absolute URLs pass through. `img` never did.

Affects skill icons, project covers, company logos, avatars, service images and testimonial avatars. Present on `master`.

## Fix

Give `img()` the same contract as `resolveFileUrl`: repo-relative paths resolve against the admin host, absolute and protocol-relative URLs pass through untouched.

Paired with mohansagark/portfolio-data#(admin preview fix), which fixes the same class of bug in the admin's read-only preview.

## Tests

Adds a `node:test` suite for `contentMapping` — the module is dependency-free by design, so plain Node can import it — plus an `npm test` script.

Three of the six tests fail on `master` and pass with this change:

- absolute skill icon URLs are left untouched
- protocol-relative skill icon URLs are left untouched
- absolute project cover URLs are left untouched

## Test plan

- [ ] `npm test` — 6 pass
- [ ] `npm run build` — compiles clean
- [ ] Set a skill icon to an external URL in the admin, redeploy, confirm the icon renders on the site
- [ ] Confirm uploaded (repo-relative) icons still render

Note: `images: { unoptimized: true }` is already set in `next.config.mjs`, so remote hosts need no `remotePatterns` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)