### PR TITLE
feat(leo): live Worker widget config + CMS instructions

### DIFF
--- a/scripts/build-leo-config.mjs
+++ b/scripts/build-leo-config.mjs
@@ -258,13 +258,21 @@ async function buildAppConfig() {
     branding: {
       botName,
       greeting: `Hi, I'm ${botName} — ${displayName}'s assistant. Ask me about their work, projects, or how to get in touch.`,
+      themeColor: "#6C5CE7",
+      themeColorSecondary: "#6C5CE7",
+      position: "bottom-right",
     },
-    behavior: { autoGreet: true, rememberReturning: true, language: "en-US" },
+    behavior: {
+      autoGreet: true,
+      rememberReturning: true,
+      language: "en-US",
+      proactiveGreet: true,
+    },
     privacy: {
       consentText: "I agree to share my info so I can be followed up with.",
       privacyPolicyUrl: null,
     },
-    voice: { enabled: true, speakByDefault: false },
+    voice: { enabled: true, speakByDefault: false, ttsVoice: "hannah" },
   };
 
   // Merge per section, so filling in one CMS subsection can't drop the other three.
@@ -276,9 +284,15 @@ async function buildAppConfig() {
   // Sveltia may store "" instead of null for optional URL fields.
   if (widget.privacy.privacyPolicyUrl === "") widget.privacy.privacyPolicyUrl = null;
 
+  const instructions =
+    typeof chatbot.instructions === "string" && chatbot.instructions.trim()
+      ? chatbot.instructions.trim()
+      : undefined;
+
   const config = {
     allowedOrigins: chatbot.allowedOrigins,
     persona,
+    ...(instructions ? { instructions } : {}),
     behavior: chatbot.behavior || {
       defaultProvider: "groq",
       maxMessageChars: 2000,

--- a/src/components/shared/others/LeoLoader.js
+++ b/src/components/shared/others/LeoLoader.js
@@ -4,43 +4,78 @@ import { useEffect } from "react";
 
 /**
  * Mounts the ai-voice-bot widget.
- * Public config is loaded from /leo-widget-config.json (generated from portfolio-data
- * by scripts/build-leo-config.mjs). API keys never pass through this component.
+ *
+ * Public config resolution order:
+ *   1. Worker GET /widget-config  (live after CMS → KV sync — no site redeploy needed)
+ *   2. /leo-widget-config.json    (written by scripts/build-leo-config.mjs at site build)
+ *   3. FALLBACK_WIDGET below
+ *
+ * API keys never pass through this component.
  */
 
 /**
- * Used when /leo-widget-config.json is missing or unreadable — a skipped prebuild, a fresh
- * clone, a bad deploy. The file is gitignored, so without this the widget would silently
- * fall back to its own generic strings ("Hi, I'm Leo — how can I help?") with no error.
+ * Used when both live Worker config and /leo-widget-config.json are missing or unreadable.
+ * The build artifact is gitignored, so without this the widget would silently fall back to
+ * its own generic strings ("Hi, I'm Leo — how can I help?") with no error.
  */
 const FALLBACK_WIDGET = {
   branding: {
     botName: "Leo",
     greeting:
       "Hi, I'm Leo — Mohan's assistant. Ask me about his work, projects, or how to get in touch.",
+    themeColor: "#6C5CE7",
+    themeColorSecondary: "#6C5CE7",
+    position: "bottom-right",
   },
-  behavior: { autoGreet: true, rememberReturning: true, language: "en-US" },
+  behavior: {
+    autoGreet: true,
+    rememberReturning: true,
+    language: "en-US",
+    proactiveGreet: true,
+  },
   privacy: {
     consentText: "I agree to share my info so I can be followed up with.",
     privacyPolicyUrl: null,
   },
   // Chat-first: TTS stays off until the visitor unmutes the sound control.
-  voice: { enabled: true, speakByDefault: false },
+  voice: { enabled: true, speakByDefault: false, ttsVoice: "hannah" },
 };
+
+async function loadWidgetConfig(workerUrl) {
+  const base = String(workerUrl || "").replace(/\/+$/, "");
+  if (base) {
+    try {
+      const res = await fetch(`${base}/widget-config`, { cache: "no-cache" });
+      if (res.ok) {
+        const body = await res.json();
+        if (body?.widget && typeof body.widget === "object") return body.widget;
+      } else {
+        console.warn(
+          `[leo] Worker /widget-config HTTP ${res.status} — trying static fallback.`,
+        );
+      }
+    } catch {
+      console.warn("[leo] Worker /widget-config unreachable — trying static fallback.");
+    }
+  }
+
+  try {
+    const res = await fetch("/leo-widget-config.json", { cache: "no-cache" });
+    if (res.ok) return await res.json();
+    console.warn(`[leo] widget config HTTP ${res.status} — using built-in defaults.`);
+  } catch {
+    console.warn("[leo] widget config unreachable — using built-in defaults.");
+  }
+  return {};
+}
+
 export default function LeoLoader({ workerUrl }) {
   useEffect(() => {
     if (typeof window === "undefined" || !workerUrl) return;
     let cancelled = false;
 
     (async () => {
-      let widget = {};
-      try {
-        const res = await fetch("/leo-widget-config.json", { cache: "no-cache" });
-        if (res.ok) widget = await res.json();
-        else console.warn(`[leo] widget config HTTP ${res.status} — using built-in defaults.`);
-      } catch {
-        console.warn("[leo] widget config unreachable — using built-in defaults.");
-      }
+      const widget = await loadWidgetConfig(workerUrl);
       if (cancelled) return;
 
       // Section-wise merge: a partial config fills gaps from FALLBACK_WIDGET rather than


### PR DESCRIPTION
## Summary
- build-leo passes `instructions` and full widget branding/voice fields
- LeoLoader prefers Worker `GET /widget-config`, then static fallback

## Test plan
- [ ] Site loads Leo with Worker config when available
- [ ] Falls back to `/leo-widget-config.json` if Worker unreachable

Made with [Cursor](https://cursor.com)