### PR TITLE
OUTPERO Figma-style UX — web and mobile artboards

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,19 @@ const nextConfig = {
   },
 
   trailingSlash: true,
+
+  async rewrites() {
+    return [
+      {
+        source: "/ux/outpero",
+        destination: "/ux/outpero/index.html",
+      },
+      {
+        source: "/ux/outpero/",
+        destination: "/ux/outpero/index.html",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/public/ux/outpero/build.py
+++ b/public/ux/outpero/build.py
@@ -1,0 +1,713 @@
+#!/usr/bin/env python3
+"""Generate the Outpero Figma-like UX canvas. Run from repo root."""
+from pathlib import Path
+
+OUT = Path("/workspace/public/ux/outpero/index.html")
+
+def logo():
+    return """<div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div>"""
+
+def nav(active, theme="agency", mobile=False):
+    links = [
+        ("home", "Home"),
+        ("employee", "Hire AI Employee"),
+        ("voice", "AI Voice Agents"),
+        ("solutions", "Solutions"),
+        ("about", "About"),
+        ("contact", "Contact"),
+    ]
+    items = []
+    for key, label in links:
+        extra = ' <span class="badge-new">NEW</span>' if key == "employee" else ""
+        cls = "active" if key == active else ""
+        items.append(f'<a class="{cls} hotspot" data-go="{key}">{label}{extra}</a>')
+    cta = f'<a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a>'
+    if theme == "product":
+        cta = f'<a class="btn btn-gold hotspot" data-go="employee">Hire now</a>'
+    if mobile:
+        return f"""<header class="nav">{logo()}<div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>"""
+    return f"""<header class="nav">{logo()}<nav class="nav-links">{''.join(items)}</nav>{cta}</header>"""
+
+def footer(mobile=False):
+    cols = """
+    <div>{logo}<p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    """.replace("{logo}", logo())
+    legal = '<div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>'
+    return f'<footer class="footer">{cols}</footer>{legal}'
+
+def diagram(product=False):
+    nodes = [
+        ("50%", "50%", "core", "YOUR<br>BUSINESS"),
+        ("22%", "28%", "", "Leads"),
+        ("78%", "24%", "", "Follow-up"),
+        ("18%", "68%", "", "Bookings"),
+        ("82%", "62%", "", "24/7 Calls"),
+        ("50%", "86%", "", "WhatsApp"),
+        ("72%", "80%", "leak", "Leaking Revenue"),
+    ]
+    html = ['<div class="diagram">']
+    html.append('<svg width="100%" height="100%" style="position:absolute;inset:0"><g stroke="#7a50dc55" stroke-width="1.5" fill="none" stroke-dasharray="4 6">')
+    for x,y,kind,label in nodes[1:]:
+        html.append(f'<line x1="50%" y1="50%" x2="{x}" y2="{y}"/>')
+    html.append('</g></svg>')
+    for x,y,kind,label in nodes:
+        html.append(f'<div class="node {kind}" style="left:{x};top:{y}">{label}</div>')
+    html.append("</div>")
+    return "".join(html)
+
+def home(mobile=False):
+    m = "mobile" if mobile else "desktop"
+    return f"""
+    <article class="ui theme-agency {m}">
+      {nav("home", mobile=mobile)}
+      <section class="hero">
+        <div class="split">
+          <div>
+            <div class="kicker">Systems that outperform</div>
+            <h1 class="display">Your business is <span class="grad">leaking</span> revenue. We seal it.</h1>
+            <p class="lede">AI automations, voice agents, and web solutions — engineered around your outcomes, not our deliverables.</p>
+            <div class="cta-row">
+              <a class="btn btn-primary hotspot" data-go="contact">Book a Free Audit</a>
+              <a class="btn btn-ghost hotspot" data-go="systems">See Our Systems</a>
+            </div>
+          </div>
+          {diagram()}
+        </div>
+      </section>
+      <div class="marquee"><span>Real Estate</span><span>Clinics & Healthcare</span><span>Coaches & Consultants</span><span>D2C Brands</span><span>Legal Firms</span><span>E-commerce</span><span>SaaS Startups</span></div>
+      <section class="section">
+        <h2 class="display">You're doing everything right. But still losing.</h2>
+        <div class="grid-3" style="margin-top:28px">
+          <div class="card"><div class="num">01</div><h3>Leads Going Cold</h3><p>78% of customers buy from whoever responds first. By the time you call back, the deal is gone.</p></div>
+          <div class="card"><div class="num">02</div><h3>Too Much Manual Work</h3><p>Teams burn 20–40 hours a week on data entry, scheduling, and reports instead of revenue.</p></div>
+          <div class="card"><div class="num">03</div><h3>Websites That Don't Convert</h3><p>Traffic lands, looks around, and leaves. No system to capture and qualify visitors.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Revenue systems</div>
+        <h2 class="display">Three systems. Each solves one expensive problem.</h2>
+        <div class="grid-3" style="margin-top:28px">
+          <div class="card hotspot" data-go="systems"><div class="num">System 1</div><h3>Revenue Capture</h3><p>Contact, qualify, and book leads in seconds.</p><ul class="checks"><li>AI Voice Agent (24/7)</li><li>WhatsApp & SMS Bot</li><li>Instant CRM Sync</li></ul><div class="price">From ₹60,000</div></div>
+          <div class="card hotspot" data-go="systems" style="box-shadow:0 0 0 1px #e2b85a, var(--shadow-card)"><span class="flagship">FLAGSHIP</span><div class="num">System 2</div><h3>Ops Efficiency</h3><p>Eliminate 20–40 hours of manual tasks weekly.</p><ul class="checks"><li>Workflow Process Mapping</li><li>3–5 Core Automations</li><li>Custom n8n/Make Logic</li></ul><div class="price">From ₹1,00,000</div></div>
+          <div class="card hotspot" data-go="systems"><div class="num">System 3</div><h3>Web Capture</h3><p>Turn passive visitors into qualified leads.</p><ul class="checks"><li>High-Converting Landing Pages</li><li>Frictionless Lead Capture</li><li>Automated WhatsApp Triggers</li></ul><div class="price">From ₹50,000</div></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Our process</div>
+        <h2 class="display">From first call to live system. In 2 weeks.</h2>
+        <div class="steps" style="margin-top:28px">
+          <div class="card"><div class="step-index">01</div><h3>We understand</h3><p>30-minute call. Find where money is leaking.</p></div>
+          <div class="card"><div class="step-index">02</div><h3>Scope & price</h3><p>Exact deliverables, timeline, and cost in writing.</p></div>
+          <div class="card"><div class="step-index">03</div><h3>We build it</h3><p>Full build and setup. You stay on the business.</p></div>
+          <div class="card"><div class="step-index">04</div><h3>Goes live</h3><p>Hours saved and revenue retained within 30 days.</p></div>
+        </div>
+        <div class="grid-4" style="margin-top:28px">
+          <div class="stat"><b>0 sec</b><span>Lead response</span></div>
+          <div class="stat"><b>0 hrs</b><span>Manual work gone</span></div>
+          <div class="stat"><b>0x</b><span>Conversion lift</span></div>
+          <div class="stat"><b>Zero</b><span>Tech headache</span></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Individual solutions</div>
+        <h2 class="display">Not ready for a full system? Start with one.</h2>
+        <p class="lede">19 pre-built solutions. Starting from ₹14,999.</p>
+        <div class="grid-2" style="margin-top:20px">
+          <div class="card hotspot" data-go="solutions"><div class="cat">AI & Automation</div><h3>Instant Lead Follow-Up</h3><p>WhatsApp + email the second a form is submitted.</p></div>
+          <div class="card hotspot" data-go="voice"><div class="cat">AI Voice</div><h3>Inbound AI Receptionist</h3><p>Answers every call, routes, and books 24/7.</p></div>
+          <div class="card hotspot" data-go="solutions"><div class="cat">Web</div><h3>High-Converting Landing Pages</h3><p>Single-page funnels built to capture and book.</p></div>
+          <div class="card hotspot" data-go="solutions"><div class="cat">AI & Automation</div><h3>Appointment Booking Bot</h3><p>Prospects book themselves. Zero calendar ping-pong.</p></div>
+        </div>
+        <div class="cta-row"><a class="btn btn-ghost hotspot" data-go="solutions">Explore all 19 solutions</a></div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Why work with us?</h2>
+        <div class="grid-2" style="margin-top:20px">
+          <div class="card"><h3>Business first, tech second</h3><p>If it will not save time or make money, we will not recommend it.</p></div>
+          <div class="card"><h3>Clear, measurable ROI</h3><p>Every system is measured by hours saved and revenue generated.</p></div>
+          <div class="card"><h3>Fast deployment</h3><p>Biggest bottleneck first. Live in weeks, not months.</p></div>
+          <div class="card"><h3>Zero technical headaches</h3><p>We build, integrate, and maintain. You get a working system.</p></div>
+        </div>
+      </section>
+      <section class="section faq" style="padding-top:0">
+        <h2 class="display">Clear answers. No jargon.</h2>
+        <details open><summary>What exactly do you build?</summary><p>Voice agents, WhatsApp/CRM automations, and conversion websites — scoped to one revenue leak at a time.</p></details>
+        <details><summary>Will I need to replace my existing software?</summary><p>No. We wire into the tools you already use.</p></details>
+        <details><summary>How long does implementation take?</summary><p>Most systems go live in two weeks after scope is signed.</p></details>
+        <details><summary>How do you charge?</summary><p>Fixed-scope agency builds from ₹14,999, or hire an AI employee at ₹1,899 / 30 days plus usage.</p></details>
+      </section>
+      <div class="cta-band">
+        <h2>Your revenue leak has a fix. Let's find it.</h2>
+        <p>Book a free 30-minute strategy call. No obligation. No pitch. Just clarity.</p>
+        <div class="cta-row">
+          <a class="btn btn-gold hotspot" data-go="contact">Book Free Audit →</a>
+          <a class="btn btn-ghost hotspot" data-go="solutions" style="color:#fff;box-shadow:inset 0 0 0 1px #fff6">Explore the Solutions →</a>
+        </div>
+      </div>
+      {footer(mobile)}
+    </article>
+    """
+
+def solutions(mobile=False):
+    items = [
+        ("AI & Automation", "WhatsApp Business Automation", "End-to-end automated WhatsApp interactions."),
+        ("AI & Automation", "AI Lead Qualification", "Automatic scoring and filtering for every lead."),
+        ("AI & Automation", "Appointment Booking Automation", "Zero-touch scheduling and reminders."),
+        ("AI Voice", "Inbound AI Voice Agent", "24/7 intelligent answering and lead routing."),
+        ("AI Voice", "Outbound AI Voice Agent", "Scalable proactive calling and engagement."),
+        ("Web", "Landing Page", "High-velocity standalone pages for campaigns."),
+        ("Web", "Website + Lead Pipeline", "Site fully wired into automated CRM follow-ups."),
+        ("Audit & Strategy", "Business Automation Audit", "Map operational leaks and ROI fixes."),
+    ]
+    cards = "".join(
+        f'<div class="sol-item"><div><div class="cat">{c}</div><h3 style="margin:4px 0 4px;font-size:16px">{t}</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">{d}</p></div><span>⌄</span></div>'
+        for c,t,d in items
+    )
+    m = "mobile" if mobile else "desktop"
+    return f"""
+    <article class="ui theme-agency {m}">
+      {nav("solutions", mobile=mobile)}
+      <section class="hero" style="text-align:center">
+        <div class="kicker">Solutions</div>
+        <h1 class="display" style="max-width:900px;margin-left:auto;margin-right:auto">Drop-in solutions for immediate ROI.</h1>
+        <p class="lede" style="margin-left:auto;margin-right:auto">19 standalone solutions. Each one targets one specific problem. Starting from ₹14,999.</p>
+        <div class="cta-row" style="justify-content:center"><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></div>
+        <div class="chips" style="justify-content:center">
+          <span class="chip-filter active">All</span>
+          <span class="chip-filter">AI & Automation</span>
+          <span class="chip-filter">AI Voice</span>
+          <span class="chip-filter">Web</span>
+          <span class="chip-filter">Audit & Strategy</span>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">{cards}
+        <p class="lede" style="margin-top:18px;font-size:13px">All fees cover build and management. Platforms billed separately at cost.</p>
+      </section>
+      <div class="cta-band">
+        <h2>Need a complete transformation?</h2>
+        <p>Stop stitching tools together. Explore the three revenue systems.</p>
+        <a class="btn btn-gold hotspot" data-go="systems">Explore Revenue Systems</a>
+      </div>
+      {footer(mobile)}
+    </article>
+    """
+
+def contact(mobile=False):
+    m = "mobile" if mobile else "desktop"
+    form = """
+      <form class="form card">
+        <div><label>Name *</label><input placeholder="Your full name"></div>
+        <div><label>Business Name *</label><input placeholder="Your company name"></div>
+        <div><label>Email *</label><input type="email" placeholder="you@company.com"></div>
+        <div><label>Phone (WhatsApp preferred) *</label><input type="tel" placeholder="+91 98765 43210"></div>
+        <div><label>Business Type *</label><select><option>Real Estate</option><option>Clinic</option><option>Coaching</option><option>D2C</option><option>Other</option></select></div>
+        <div><label>Business Size *</label><select><option>Solo (1 person)</option><option>2-10 employees</option><option>11-50 employees</option></select></div>
+        <div><label>Biggest Challenge *</label><textarea placeholder="What is the biggest operational or growth challenge right now?"></textarea></div>
+        <button class="btn btn-primary btn-block" type="button">Book My Free Audit</button>
+      </form>
+    """
+    return f"""
+    <article class="ui theme-agency {m}">
+      {nav("contact", mobile=mobile)}
+      <section class="hero">
+        <div class="split">
+          <div>
+            <div class="kicker">Contact</div>
+            <h1 class="display">Book your free business audit.</h1>
+            <p class="lede">30 minutes. We'll show you exactly where you're losing money and what to build first.</p>
+            <div class="card" style="margin-top:24px">
+              <b>What to expect</b>
+              <ul class="checks">
+                <li>Review current workflows or website</li>
+                <li>Identify 2–3 immediate quick wins</li>
+                <li>Map the highest-ROI system</li>
+                <li>Give a written estimate</li>
+              </ul>
+              <p style="margin-top:16px;font-size:13px">We respond within 24 hours · hello@outpero.com</p>
+            </div>
+            <a class="btn btn-ghost hotspot" data-go="voice" style="margin-top:16px">Looking for a voice agent? Explore →</a>
+          </div>
+          {form}
+        </div>
+      </section>
+      {footer(mobile)}
+    </article>
+    """
+
+def about(mobile=False):
+    m = "mobile" if mobile else "desktop"
+    return f"""
+    <article class="ui theme-agency {m}">
+      {nav("about", mobile=mobile)}
+      <section class="hero">
+        <h1 class="display">We understand business first.<br>Technology second.</h1>
+        <p class="lede">Most agencies sell tools, not outcomes. OUTPERO starts with the leak, then engineers the system that seals it.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Philosophy</div>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card"><h3>Outcome-first</h3><p>Measured by the result it creates for your business.</p></div>
+          <div class="card"><h3>Business audit always</h3><p>We map workflows before writing a line of code.</p></div>
+          <div class="card"><h3>ROI tracked</h3><p>Time saved. Revenue captured. Costs cut.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">What we build</div>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card hotspot" data-go="systems"><h3>Revenue Capture</h3><p>Instant lead response, qualification, and booking — 24/7.</p></div>
+          <div class="card hotspot" data-go="systems"><h3>Ops Efficiency</h3><p>Eliminate 20–40 hours of manual work every week.</p></div>
+          <div class="card hotspot" data-go="systems"><h3>Digital Salesman</h3><p>Websites that convert, wired to automated pipelines.</p></div>
+        </div>
+      </section>
+      <div class="cta-band"><h2>Have a specific problem?</h2><p>Reach the founder at vatsal@outpero.com or book an audit.</p><a class="btn btn-gold hotspot" data-go="contact">Book Free Audit</a></div>
+      {footer(mobile)}
+    </article>
+    """
+
+def systems(mobile=False):
+    m = "mobile" if mobile else "desktop"
+    return f"""
+    <article class="ui theme-agency {m}">
+      {nav("solutions", mobile=mobile)}
+      <section class="hero" style="text-align:center">
+        <div class="kicker">Revenue systems</div>
+        <h1 class="display">The Big Three</h1>
+        <p class="lede" style="margin:0 auto">End-to-end systems for lead capture, operations, and web. Fixed scope. Fixed price.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="grid-3">
+          <div class="card"><div class="num">System 1</div><h3>Revenue Capture</h3><p>From ₹60,000</p><ul class="checks"><li>AI Voice Agent</li><li>WhatsApp & SMS</li><li>CRM sync</li><li>Missed-call textback</li></ul><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:16px">Get this system</a></div>
+          <div class="card" style="box-shadow:0 0 0 1px #e2b85a, var(--shadow-card)"><span class="flagship">FLAGSHIP</span><div class="num">System 2</div><h3>Ops Efficiency</h3><p>From ₹1,00,000</p><ul class="checks"><li>Process mapping</li><li>3–5 automations</li><li>n8n / Make logic</li><li>Handover docs</li></ul><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:16px">Get this system</a></div>
+          <div class="card"><div class="num">System 3</div><h3>Web Capture</h3><p>From ₹50,000</p><ul class="checks"><li>Landing pages</li><li>Lead capture</li><li>WhatsApp triggers</li><li>Analytics</li></ul><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:16px">Get this system</a></div>
+        </div>
+      </section>
+      {footer(mobile)}
+    </article>
+    """
+
+def employee(mobile=False):
+    m = "mobile" if mobile else "desktop"
+    return f"""
+    <article class="ui theme-product {m}">
+      {nav("employee", theme="product", mobile=mobile)}
+      <section class="hero">
+        <div class="split">
+          <div>
+            <div class="kicker">Andhra & Telangana</div>
+            <h1 class="display">Hire the fastest <span class="telugu" style="color:var(--op-gold)">తెలుగు</span> employee.</h1>
+            <p class="lede">Skip the ₹30k agency setup fee. Hire it yourself in 5 minutes. Native Telugu, English mid-call, dedicated +91 number.</p>
+            <div class="cta-row">
+              <a class="btn btn-gold hotspot" data-go="pricing">See pricing ₹1,899/mo</a>
+              <a class="btn btn-ghost hotspot" data-go="voice">Hear a sample call</a>
+            </div>
+          </div>
+          <div class="diagram">
+            <div class="node core" style="left:50%;top:50%">AI<br>Employee</div>
+            <div class="node" style="left:22%;top:28%">+91 number</div>
+            <div class="node" style="left:80%;top:30%">CRM sync</div>
+            <div class="node" style="left:24%;top:74%">WhatsApp</div>
+            <div class="node" style="left:78%;top:72%">Calendar</div>
+          </div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">One employee, two ways to work.</h2>
+        <div class="grid-2" style="margin-top:24px">
+          <div class="card"><div class="num">01</div><h3>Instant lead calling</h3><p>New Facebook / website lead? The agent calls in seconds, qualifies, and books.</p></div>
+          <div class="card"><div class="num">02</div><h3>Bulk campaigns</h3><p>Launch to thousands at once. Reminders, follow-ups, promo blasts — 24/7.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Who is this best for?</h2>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card"><h3>Real Estate & Builders</h3><p>Call site-visit leads before they bounce to the next listing.</p></div>
+          <div class="card"><h3>Coaching & Admissions</h3><p>Counsel every enquiry the same hour it comes in.</p></div>
+          <div class="card"><h3>Hospitals & Diagnostics</h3><p>Book appointments and never miss a ringing reception line.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Compliance</div>
+        <div class="grid-3" style="margin-top:16px">
+          <div class="card"><h3>DLT numbers</h3><p>Dedicated +91 line, TRAI-aware outbound.</p></div>
+          <div class="card"><h3>DNC screening</h3><p>Indian calling compliance built into the job, not bolted on.</p></div>
+          <div class="card"><h3>Recordings</h3><p>Every call transcribed and stored in Voice Hub.</p></div>
+        </div>
+      </section>
+      <div class="cta-band" style="background:linear-gradient(135deg,#14110a,#3a2a10 50%,#e2b85a)">
+        <h2>Ready in 5 minutes.</h2>
+        <p>No developer. No contract. Pause anytime.</p>
+        <a class="btn btn-gold hotspot" data-go="pricing">Hire an AI employee</a>
+      </div>
+      {footer(mobile)}
+    </article>
+    """
+
+def pricing(mobile=False):
+    m = "mobile" if mobile else "desktop"
+    return f"""
+    <article class="ui theme-product {m}">
+      {nav("employee", theme="product", mobile=mobile)}
+      <section class="hero" style="text-align:center">
+        <div class="kicker">Pricing</div>
+        <h1 class="display">One price, published.</h1>
+        <p class="lede" style="margin:0 auto">₹1,899 to hire an AI employee for 30 days, plus calls from ₹3 a minute. No setup fee. No sales call to hear the number.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="grid-2">
+          <div class="card" style="text-align:left">
+            <div class="kicker">Hiring fee</div>
+            <h2 class="display">₹1,899 <span style="font-size:18px;opacity:.7">/ 30 days</span></h2>
+            <ul class="checks">
+              <li>1 dedicated AI employee</li>
+              <li>Dedicated +91 DLT number</li>
+              <li>500 credits on every hire</li>
+              <li>+300 bonus on first hire</li>
+              <li>Dashboard, webhooks, CRM</li>
+              <li>99.9% uptime SLA</li>
+            </ul>
+            <a class="btn btn-gold btn-block hotspot" data-go="employee" style="margin-top:18px">Hire now</a>
+          </div>
+          <div>
+            <h3 style="margin-top:0">Voice tiers — pick per employee</h3>
+            <div class="card" style="margin-bottom:10px"><b>Value ₹3/min</b><p>Budget-friendly, covers most day-to-day calling.</p></div>
+            <div class="card" style="margin-bottom:10px"><b>Standard ₹5/min</b><p>A step up in naturalness for everyday quality.</p></div>
+            <div class="card"><b>Premium ₹7/min</b><p>Most lifelike — for the first voice a prospect hears.</p></div>
+          </div>
+        </div>
+        <h2 class="display" style="margin-top:48px">Compared with a telecaller</h2>
+        <table class="table">
+          <tr><th></th><th>Outpero</th><th>Human telecaller</th></tr>
+          <tr><td>Hiring cost</td><td>₹1,899 / 30 days</td><td>₹18,000</td></tr>
+          <tr><td>Hours</td><td>24/7</td><td>One shift</td></tr>
+          <tr><td>Concurrency</td><td>Up to 20</td><td>One</td></tr>
+          <tr><td>Training</td><td>Same day</td><td>2–6 weeks</td></tr>
+        </table>
+      </section>
+      {footer(mobile)}
+    </article>
+    """
+
+def voice(mobile=False):
+    m = "mobile" if mobile else "desktop"
+    return f"""
+    <article class="ui theme-product {m}">
+      {nav("voice", theme="product", mobile=mobile)}
+      <section class="hero">
+        <div class="kicker">Telugu-first voice AI</div>
+        <h1 class="display">AI voice agents for Indian businesses.</h1>
+        <p class="lede">Instant lead response. Native Telugu, Hindi, and English. Inbound, outbound, and bulk — one employee.</p>
+        <div class="cta-row">
+          <a class="btn btn-gold hotspot" data-go="employee">Deploy AI Voice Agent</a>
+          <a class="btn btn-ghost">How it works</a>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Hear the AI in action</h2>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card voice-card"><div class="avatar"></div><div><div class="cat">Native Telugu</div><b class="telugu">శాంతి</b><p>Warm & conversational</p></div><div class="play">▶</div></div>
+          <div class="card voice-card"><div class="avatar"></div><div><div class="cat">Native Telugu</div><b class="telugu">Bhaskar</b><p>Energetic & upbeat</p></div><div class="play">▶</div></div>
+          <div class="card voice-card"><div class="avatar"></div><div><div class="cat">Native Telugu</div><b class="telugu">Sahana</b><p>Deep & professional</p></div><div class="play">▶</div></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">How it actually works</h2>
+        <div class="steps" style="margin-top:20px">
+          <div class="card"><div class="step-index">1</div><h3>Lead captured</h3><p>Facebook ad or website form fires.</p></div>
+          <div class="card"><div class="step-index">2</div><h3>3-second call</h3><p>Agent calls before they close the tab.</p></div>
+          <div class="card"><div class="step-index">3</div><h3>Qualifies</h3><p>Handles objections, books the visit.</p></div>
+          <div class="card"><div class="step-index">4</div><h3>Voice Hub</h3><p>Recording, transcript, intent score.</p></div>
+        </div>
+      </section>
+      {footer(mobile)}
+    </article>
+    """
+
+def compare(mobile=False):
+    m = "mobile" if mobile else "desktop"
+    return f"""
+    <article class="ui theme-agency {m}">
+      {nav("home", mobile=mobile)}
+      <section class="hero">
+        <div class="kicker">Compare</div>
+        <h1 class="display">Sourced, line-by-line comparisons.</h1>
+        <p class="lede">Including a plain statement of where the competitor is genuinely ahead. If a comparison never admits a weakness, it is marketing.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Regional Telugu & India voice AI</h2>
+        <div class="grid-2" style="margin-top:16px">
+          <div class="card hotspot" data-go="pricing"><h3>Outpero vs Edesy</h3><p>One flat price. No ₹14,999/month tier to unlock an uptime SLA.</p></div>
+          <div class="card"><h3>Outpero vs Zudu AI</h3><p>We publish the number. Their page only offers a demo.</p></div>
+          <div class="card"><h3>Outpero vs Bolna / Vapi</h3><p>Those are developer platforms. This is a finished employee.</p></div>
+          <div class="card"><h3>Outpero vs human telecaller</h3><p>Speed, cost, and concurrency — with a human still on novel cases.</p></div>
+        </div>
+      </section>
+      {footer(mobile)}
+    </article>
+    """
+
+def blog(mobile=False):
+    m = "mobile" if mobile else "desktop"
+    posts = [
+        "Cheapest AI Voice Agent in India (2026): ₹3/Min",
+        "Are AI Calling Agents Legal in India? TRAI, DLT & DNC",
+        "Best AI Receptionist for Clinics in AP & Telangana",
+        "Telugu AI Voice Agent vs Human Telecaller",
+    ]
+    cards = "".join(f'<div class="card"><div class="cat">Guide</div><h3>{p}</h3><p>Practical, India-specific. No jargon.</p></div>' for p in posts)
+    return f"""
+    <article class="ui theme-agency {m}">
+      {nav("home", mobile=mobile)}
+      <section class="hero">
+        <div class="kicker">Resources</div>
+        <h1 class="display">Blog</h1>
+        <p class="lede">Voice AI, Telugu calling, pricing, and compliance — written for operators, not developers.</p>
+      </section>
+      <section class="section" style="padding-top:0"><div class="grid-2">{cards}</div></section>
+      {footer(mobile)}
+    </article>
+    """
+
+def menu():
+    return f"""
+    <article class="ui theme-agency mobile" style="position:relative;min-height:844px">
+      {nav("home", mobile=True)}
+      <div class="menu-sheet">
+        <div class="menu-panel">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px"><b>Menu</b><span class="hotspot" data-go="home">✕</span></div>
+          <a class="hotspot" data-go="home">Home</a>
+          <a class="hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a>
+          <a class="hotspot" data-go="voice">AI Voice Agents</a>
+          <a class="hotspot" data-go="solutions">Solutions</a>
+          <a class="hotspot" data-go="about">About</a>
+          <a class="hotspot" data-go="contact">Contact</a>
+          <a class="hotspot" data-go="pricing">Pricing</a>
+          <a class="btn btn-primary btn-block hotspot" data-go="contact" style="margin-top:20px">Book Free Audit</a>
+        </div>
+      </div>
+    </article>
+    """
+
+def design_system():
+    colors = [
+        ("#FAF8F5", "#111", "Cream / Agency bg"),
+        ("#050505", "#fff", "Deep / Product bg"),
+        ("#7A50DC", "#fff", "Purple / Primary"),
+        ("#673FC4", "#fff", "Purple deep"),
+        ("#E2B85A", "#1a1304", "Gold / Accent"),
+        ("#818CF8", "#111", "Indigo glow"),
+        ("#0A0A0A", "#fff", "Ink"),
+        ("#737373", "#fff", "Muted"),
+    ]
+    sw = "".join(f'<div class="ds-color" style="background:{c};color:{t}">{n}<br>{c}</div>' for c,t,n in colors)
+    return f"""
+    <article class="ds-wrap">
+      <div class="kicker">Foundation</div>
+      <h1 class="display" style="font-size:48px">OUTPERO design system</h1>
+      <p class="lede">Two themes, one brand. Agency light for trust and audits. Product dark for hiring the AI employee.</p>
+      <h2 style="margin-top:36px">Color</h2>
+      <div class="ds-grid">{sw}</div>
+      <h2 style="margin-top:36px">Type</h2>
+      <div class="ds-type" style="font-family:Poppins,sans-serif;font-size:40px;font-weight:700">Poppins / Display</div>
+      <div class="ds-type" style="font-size:18px">Inter / Body — 16px / 1.5 — minimum 16px on mobile inputs</div>
+      <div class="ds-type telugu" style="font-size:28px">Noto Sans Telugu / Native voice UI</div>
+      <h2 style="margin-top:36px">Components</h2>
+      <div class="cta-row">
+        <a class="btn btn-primary">Primary CTA</a>
+        <a class="btn btn-gold">Product CTA</a>
+        <a class="btn btn-ghost">Secondary</a>
+      </div>
+      <div class="grid-3" style="margin-top:20px">
+        <div class="card"><div class="cat">Card</div><h3>Glass surface</h3><p>20px radius, 1px border, blur.</p></div>
+        <div class="card"><span class="flagship">FLAGSHIP</span><h3>Highlight</h3><p>Gold ring for recommended plan.</p></div>
+        <div class="card"><label style="font-size:12px;font-weight:600">Input</label><input style="width:100%;margin-top:8px;padding:12px;border-radius:12px;border:1px solid #0002" placeholder="16px text, 44px tall"></div>
+      </div>
+      <h2 style="margin-top:36px">Breakpoints</h2>
+      <p>390 mobile · 768 tablet · 1024 laptop · 1440 desktop · 1920 wall</p>
+      <p>Touch targets ≥ 44px. Nav collapses under 768. Grids 3→1. Process 4→stack. Footer 4→1.</p>
+    </article>
+    """
+
+def cover():
+    thumbs = "".join(
+        f'<div class="thumb {t}"><b>{n}</b><span>{d}</span></div>'
+        for n, d, t in [
+            ("Home", "Agency · 1440 / 390", "light"),
+            ("Solutions", "19 SKUs · filters", "light"),
+            ("Contact", "Audit form", "light"),
+            ("AI Employee", "Product dark", "dark"),
+            ("Pricing", "₹1899 + usage", "dark"),
+            ("Voice", "Telugu samples", "dark"),
+        ]
+    )
+    return f"""
+    <article class="cover">
+      <div>
+        <div class="kicker">UX file · Desktop + Mobile</div>
+        <h1>OUTPERO<br>experience design</h1>
+        <p>High-fidelity artboards reverse-engineered from outpero.com. Agency light for conversion. Product dark for the AI employee. Switch to Prototype and click CTAs to walk the paths.</p>
+        <div class="thumbs">{thumbs}</div>
+      </div>
+      <div class="cover-meta">
+        <div><b>Artboards</b>13 pages · 23 frames</div>
+        <div><b>Breakpoints</b>1440 desktop · 390 mobile</div>
+        <div><b>Themes</b>Agency cream · Product cinematic</div>
+        <div><b>Primary CTA</b>Book Free Audit → Contact</div>
+      </div>
+    </article>
+    """
+
+def flows():
+    nodes = [
+        (80, 80, "start", "Visitor lands", "Home · 1440 / 390"),
+        (380, 60, "cta", "Book audit", "Contact form"),
+        (380, 220, "cta", "See systems", "Revenue systems"),
+        (380, 380, "cta", "Hire employee", "AI Employee dark"),
+        (700, 60, "", "Audit booked", "Email + WhatsApp"),
+        (700, 220, "cta", "Pick a system", "₹50k–1L scope"),
+        (700, 380, "cta", "Pricing", "₹1899 + ₹3/min"),
+        (1020, 380, "", "Self-serve hire", "5 min deploy"),
+        (1020, 220, "", "Build in 2 weeks", "Agency delivery"),
+        (80, 560, "", "Mobile menu", "Hamburger overlay"),
+        (380, 560, "", "Solutions catalogue", "19 drop-in SKUs"),
+        (700, 560, "", "Compare / Blog", "Trust & SEO"),
+    ]
+    html = ['<div class="flow">']
+    html.append('<svg width="1600" height="900" style="position:absolute;inset:0"><g stroke="#a259ff" stroke-width="2" fill="none">')
+    html.append('<path d="M300 120 H380"/><path d="M300 140 C340 140,340 260,380 260"/><path d="M300 160 C340 160,340 420,380 420"/>')
+    html.append('<path d="M600 100 H700"/><path d="M600 260 H700"/><path d="M600 420 H700"/>')
+    html.append('<path d="M920 420 H1020"/><path d="M920 260 H1020"/>')
+    html.append("</g></svg>")
+    for x,y,kind,title,sub in nodes:
+        html.append(f'<div class="flow-node {kind}" style="left:{x}px;top:{y}px"><b>{title}</b>{sub}</div>')
+    html.append("</div>")
+    return "".join(html)
+
+PAGES = [
+    ("cover", "Cover", [
+        ("cover-desktop", "Cover", "desktop", 80, 80, cover()),
+    ]),
+    ("ds", "Design system", [
+        ("ds-desktop", "Design system / Desktop", "desktop", 80, 80, design_system()),
+    ]),
+    ("home", "Home", [
+        ("home-desktop", "Home / Desktop 1440", "desktop", 80, 80, home(False)),
+        ("home-mobile", "Home / Mobile 390", "mobile", 1600, 80, home(True)),
+    ]),
+    ("solutions", "Solutions", [
+        ("sol-desktop", "Solutions / Desktop", "desktop", 80, 80, solutions(False)),
+        ("sol-mobile", "Solutions / Mobile", "mobile", 1600, 80, solutions(True)),
+    ]),
+    ("contact", "Contact", [
+        ("con-desktop", "Contact / Desktop", "desktop", 80, 80, contact(False)),
+        ("con-mobile", "Contact / Mobile", "mobile", 1600, 80, contact(True)),
+    ]),
+    ("about", "About", [
+        ("about-desktop", "About / Desktop", "desktop", 80, 80, about(False)),
+        ("about-mobile", "About / Mobile", "mobile", 1600, 80, about(True)),
+    ]),
+    ("systems", "Revenue systems", [
+        ("sys-desktop", "Revenue systems / Desktop", "desktop", 80, 80, systems(False)),
+        ("sys-mobile", "Revenue systems / Mobile", "mobile", 1600, 80, systems(True)),
+    ]),
+    ("employee", "Hire AI Employee", [
+        ("emp-desktop", "AI Employee / Desktop", "desktop", 80, 80, employee(False)),
+        ("emp-mobile", "AI Employee / Mobile", "mobile", 1600, 80, employee(True)),
+    ]),
+    ("pricing", "Pricing", [
+        ("price-desktop", "Pricing / Desktop", "desktop", 80, 80, pricing(False)),
+        ("price-mobile", "Pricing / Mobile", "mobile", 1600, 80, pricing(True)),
+    ]),
+    ("voice", "Voice agents", [
+        ("voice-desktop", "Voice / Desktop", "desktop", 80, 80, voice(False)),
+        ("voice-mobile", "Voice / Mobile", "mobile", 1600, 80, voice(True)),
+    ]),
+    ("compare", "Compare + Blog", [
+        ("cmp-desktop", "Compare / Desktop", "desktop", 80, 80, compare(False)),
+        ("blog-desktop", "Blog / Desktop", "desktop", 1600, 80, blog(False)),
+        ("blog-mobile", "Blog / Mobile", "mobile", 3120, 80, blog(True)),
+    ]),
+    ("menu", "Mobile menu", [
+        ("menu-mobile", "Mobile menu / 390", "mobile", 80, 80, menu()),
+    ]),
+    ("flows", "User flows", [
+        ("flows-desktop", "Primary conversion map", "desktop", 80, 80, flows()),
+    ]),
+]
+
+def frame(fid, label, device, x, y, inner):
+    w = 1440 if device == "desktop" else 390
+    return f'''
+    <div class="frame-wrap" data-frame="{fid}" data-page-owner="" style="left:{x}px;top:{y}px">
+      <div class="frame-label">{label}</div>
+      <div class="artboard {device}" style="width:{w}px">{inner}</div>
+    </div>'''
+
+page_html = []
+for pid, pname, frames in PAGES:
+    blocks = []
+    for fid, label, device, x, y, inner in frames:
+        block = frame(fid, label, device, x, y, inner)
+        block = block.replace('data-page-owner=""', f'data-page-owner="{pid}"')
+        blocks.append(block)
+    page_html.append(f'<div class="canvas-page" data-page="{pid}" hidden>{"".join(blocks)}</div>')
+
+page_items = []
+for pid, pname, frames in PAGES:
+    page_items.append(f'<button class="page-item" data-page="{pid}">{pname}<span>{len(frames)}</span></button>')
+
+html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" href="./favicon.svg" />
+  <link rel="stylesheet" href="./css/tokens.css" />
+  <link rel="stylesheet" href="./css/studio.css" />
+  <link rel="stylesheet" href="./css/screens.css" />
+</head>
+<body class="studio design-mode">
+  <header class="topbar">
+    <div class="topbar-left">
+      <strong class="file-name">OUTPERO UX</strong>
+      <span class="chip">Draft</span>
+    </div>
+    <div class="topbar-center">
+      <div class="mode-switch">
+        <button class="active" data-mode="design">Design</button>
+        <button data-mode="prototype">Prototype</button>
+        <button data-mode="inspect">Inspect</button>
+      </div>
+    </div>
+    <div class="topbar-right">
+      <button class="chip" id="zoomOut">−</button>
+      <span class="zoom-readout" id="zoomReadout">35%</span>
+      <button class="chip" id="zoomIn">+</button>
+      <button class="chip" id="zoomFit">Fit</button>
+    </div>
+  </header>
+  <div class="layout">
+    <aside class="panel panel-left">
+      <h3>Pages</h3>
+      <div class="pages">{''.join(page_items)}</div>
+      <h3>Layers</h3>
+      <div class="layers" id="layers"></div>
+    </aside>
+    <main class="canvas-wrap" id="canvasWrap">
+      <div class="canvas" id="canvas">{''.join(page_html)}</div>
+      <div class="hint">Space + drag to pan · Scroll to zoom · Prototype mode: click CTAs</div>
+    </main>
+    <aside class="panel panel-right inspect" id="inspect">
+      <h3>Inspect</h3>
+      <p style="color:#aaa;padding:8px 0">Select a frame to see tokens, type, and spacing.</p>
+    </aside>
+  </div>
+  <script src="./js/studio.js"></script>
+</body>
+</html>
+"""
+OUT.write_text(html)
+print("wrote", OUT, "bytes", OUT.stat().st_size)
+print("pages", len(PAGES), "frames", sum(len(p[2]) for p in PAGES))

--- a/public/ux/outpero/css/screens.css
+++ b/public/ux/outpero/css/screens.css
@@ -1,0 +1,257 @@
+.ui { font-family: var(--font-body); color: var(--op-ink); }
+.ui * { box-sizing: border-box; }
+.theme-agency { background: var(--op-cream); color: var(--op-ink); }
+.theme-product { background: var(--op-deep); color: #fafafa; }
+
+.nav {
+  position: sticky; top: 0; z-index: 8;
+  display: flex; align-items: center; justify-content: space-between;
+  height: 72px; padding: 0 40px;
+  backdrop-filter: blur(16px);
+}
+.theme-agency .nav { background: rgba(250,248,245,.86); border-bottom: 1px solid var(--op-border); }
+.theme-product .nav { background: rgba(5,5,5,.72); border-bottom: 1px solid var(--op-border-dark); }
+.nav-links { display: flex; gap: 22px; align-items: center; }
+.nav-links a {
+  font-size: 14px; font-weight: 500; color: inherit; text-decoration: none; opacity: .78;
+}
+.nav-links a.active, .nav-links a:hover { opacity: 1; }
+.badge-new {
+  font-size: 10px; font-weight: 700; background: var(--op-gold); color: #1a1304;
+  padding: 2px 6px; border-radius: 999px; margin-left: 6px; letter-spacing: .04em;
+}
+.logo {
+  display: flex; align-items: center; gap: 8px; font-weight: 800; letter-spacing: .08em;
+  font-family: var(--font-display); font-size: 18px;
+}
+.logo-mark {
+  width: 22px; height: 22px; border-radius: 50%;
+  border: 2px solid var(--op-purple); display: grid; place-items: center;
+  box-shadow: 0 0 0 3px rgba(122,80,220,.15);
+}
+.logo-mark span { width: 8px; height: 8px; border-radius: 50%; background: var(--op-purple); }
+
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  border: 0; cursor: pointer; text-decoration: none; font-weight: 600; font-size: 14px;
+  border-radius: var(--r-pill); padding: 12px 22px; line-height: 1;
+  transition: transform .2s var(--ease), box-shadow .2s var(--ease), background .2s;
+}
+.btn-primary {
+  background: linear-gradient(180deg, #8b63ee, var(--op-purple-deep));
+  color: #fff; box-shadow: var(--shadow-glow);
+}
+.btn-gold {
+  background: linear-gradient(180deg, #f0cc76, var(--op-gold-dim));
+  color: #1a1304; box-shadow: 0 10px 28px rgba(226,184,90,.35);
+}
+.btn-ghost {
+  background: transparent; color: inherit;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,.12);
+}
+.theme-product .btn-ghost { box-shadow: inset 0 0 0 1px rgba(255,255,255,.18); color: #fff; }
+.btn-block { width: 100%; }
+.icon-round {
+  width: 36px; height: 36px; border-radius: 50%; display: grid; place-items: center;
+  border: 1px solid var(--op-border); background: transparent; color: inherit;
+}
+
+.hero, .section { padding: 72px 80px; }
+.mobile .hero, .mobile .section { padding: 28px 20px; }
+.kicker {
+  font-size: 12px; letter-spacing: .22em; text-transform: uppercase; font-weight: 600;
+  color: var(--op-purple);
+}
+.theme-product .kicker { color: var(--op-gold); }
+h1.display {
+  font-family: var(--font-display); font-weight: 700; letter-spacing: -.03em;
+  font-size: 64px; line-height: 1.05; margin: 14px 0 18px;
+}
+.mobile h1.display { font-size: 34px; }
+h2.display {
+  font-family: var(--font-display); font-weight: 700; letter-spacing: -.02em;
+  font-size: 42px; line-height: 1.15; margin: 0 0 12px;
+}
+.mobile h2.display { font-size: 28px; }
+.lede { font-size: 18px; line-height: 1.55; color: var(--op-muted-2); max-width: 640px; }
+.theme-product .lede { color: #c4c4c4; }
+.mobile .lede { font-size: 15px; }
+.grad {
+  background: linear-gradient(90deg, var(--op-purple), #5b7cfa);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+.cta-row { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 28px; }
+
+.split { display: grid; grid-template-columns: 1.05fr .95fr; gap: 48px; align-items: center; }
+.mobile .split { grid-template-columns: 1fr; gap: 28px; }
+
+.diagram {
+  height: 420px; border-radius: 28px; position: relative;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(122,80,220,.16), transparent 55%),
+    linear-gradient(180deg, #fff, #f4efe8);
+  box-shadow: var(--shadow-card);
+}
+.theme-product .diagram {
+  background:
+    radial-gradient(circle at 50% 50%, rgba(226,184,90,.14), transparent 55%),
+    linear-gradient(180deg, #121212, #070707);
+  box-shadow: 0 8px 32px rgba(0,0,0,.4), 0 0 0 1px var(--op-border-dark);
+}
+.node {
+  position: absolute; transform: translate(-50%, -50%);
+  background: #fff; border-radius: 999px; padding: 8px 12px; font-size: 12px; font-weight: 600;
+  box-shadow: 0 8px 20px rgba(0,0,0,.08); white-space: nowrap;
+}
+.theme-product .node { background: #161616; color: #fff; box-shadow: 0 8px 20px rgba(0,0,0,.4); }
+.node.core {
+  width: 132px; height: 132px; border-radius: 50%; display: grid; place-items: center;
+  text-align: center; padding: 12px; white-space: normal; font-size: 12px;
+  background: #111; color: #fff; box-shadow: 0 0 0 8px rgba(122,80,220,.12), var(--shadow-glow);
+}
+.node.leak { background: #fff3; color: #b42318; border: 1px dashed #e11; }
+
+.marquee {
+  overflow: hidden; border-top: 1px solid var(--op-border); border-bottom: 1px solid var(--op-border);
+  padding: 16px 0; display: flex; gap: 28px;
+}
+.marquee span {
+  white-space: nowrap; font-size: 14px; font-weight: 600; opacity: .7;
+}
+
+.grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+.grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+.mobile .grid-3, .mobile .grid-2, .mobile .grid-4 { grid-template-columns: 1fr; }
+
+.card {
+  background: rgba(255,255,255,.72); border: 1px solid var(--op-border);
+  border-radius: 20px; padding: 22px; backdrop-filter: blur(10px);
+}
+.theme-product .card {
+  background: rgba(255,255,255,.04); border-color: var(--op-border-dark);
+}
+.card h3 { margin: 8px 0 8px; font-size: 20px; }
+.card p { margin: 0; color: var(--op-muted-2); font-size: 14px; line-height: 1.5; }
+.theme-product .card p { color: #bdbdbd; }
+.num { font-size: 12px; font-weight: 700; color: var(--op-purple); letter-spacing: .08em; }
+.flagship {
+  display: inline-block; font-size: 10px; font-weight: 700; letter-spacing: .08em;
+  background: var(--op-gold); color: #1a1304; padding: 3px 8px; border-radius: 999px;
+}
+.price { font-weight: 700; margin-top: 16px; }
+.checks { list-style: none; padding: 0; margin: 14px 0 0; }
+.checks li { font-size: 13px; padding: 6px 0 6px 18px; position: relative; }
+.checks li::before { content: "✓"; position: absolute; left: 0; color: var(--op-purple); font-weight: 700; }
+
+.steps { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.mobile .steps { grid-template-columns: 1fr; }
+.step-index {
+  width: 36px; height: 36px; border-radius: 50%; display: grid; place-items: center;
+  background: #111; color: #fff; font-weight: 700; font-size: 13px; margin-bottom: 12px;
+}
+.theme-product .step-index { background: var(--op-gold); color: #1a1304; }
+
+.stat { text-align: center; padding: 18px 8px; }
+.stat b { display: block; font-family: var(--font-display); font-size: 36px; }
+.stat span { font-size: 13px; color: var(--op-muted); }
+
+.faq details {
+  border-bottom: 1px solid var(--op-border); padding: 14px 0;
+}
+.theme-product .faq details { border-color: var(--op-border-dark); }
+.faq summary { cursor: pointer; font-weight: 600; font-size: 15px; }
+.faq p { color: var(--op-muted-2); font-size: 14px; line-height: 1.5; }
+
+.cta-band {
+  margin: 0 80px 80px; border-radius: 28px; padding: 48px;
+  background: linear-gradient(135deg, #1a102c, #3b1d73 55%, #7a50dc);
+  color: #fff;
+}
+.mobile .cta-band { margin: 0 20px 32px; padding: 28px 20px; }
+.cta-band h2 { font-family: var(--font-display); font-size: 36px; margin: 0 0 10px; }
+.mobile .cta-band h2 { font-size: 26px; }
+.cta-band p { color: #ddd; max-width: 560px; }
+
+.footer {
+  display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr; gap: 28px;
+  padding: 48px 80px 24px; border-top: 1px solid var(--op-border);
+}
+.mobile .footer { grid-template-columns: 1fr; padding: 28px 20px; }
+.footer a { display: block; color: inherit; text-decoration: none; opacity: .75; font-size: 13px; padding: 4px 0; }
+.legal { padding: 0 80px 28px; font-size: 12px; opacity: .6; }
+.mobile .legal { padding: 0 20px 20px; }
+
+.form { display: grid; gap: 12px; }
+.form label { font-size: 12px; font-weight: 600; }
+.form input, .form select, .form textarea {
+  width: 100%; border-radius: 12px; border: 1px solid var(--op-border);
+  padding: 12px 14px; font: 400 16px var(--font-body); background: #fff; color: #111;
+}
+.form textarea { min-height: 110px; resize: none; }
+.chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 20px 0; }
+.chip-filter {
+  border-radius: 999px; padding: 8px 14px; font-size: 13px; font-weight: 600;
+  border: 1px solid var(--op-border); background: transparent; color: inherit;
+}
+.chip-filter.active { background: #111; color: #fff; border-color: #111; }
+.theme-product .chip-filter.active { background: #efe7ff; color: #1a102c; border-color: #efe7ff; }
+
+.sol-item {
+  display: flex; justify-content: space-between; gap: 12px; align-items: flex-start;
+  padding: 18px; border-radius: 16px; border: 1px solid var(--op-border); margin-bottom: 10px;
+  background: rgba(255,255,255,.6);
+}
+.theme-product .sol-item { background: rgba(255,255,255,.03); border-color: var(--op-border-dark); }
+.cat { font-size: 11px; font-weight: 700; letter-spacing: .08em; color: var(--op-purple); text-transform: uppercase; }
+
+.table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.table th, .table td { text-align: left; padding: 12px 10px; border-bottom: 1px solid var(--op-border); }
+.theme-product .table th, .theme-product .table td { border-color: var(--op-border-dark); }
+.table th { color: var(--op-muted); font-weight: 600; }
+
+.phone-chrome {
+  position: absolute; inset: 0; pointer-events: none;
+  border-radius: inherit;
+}
+
+.ds-wrap { padding: 48px; background: var(--op-cream); min-height: 1100px; color: #111; }
+.ds-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-top: 24px; }
+.ds-color { height: 88px; border-radius: 16px; display: flex; align-items: flex-end; padding: 10px; color: #fff; font-size: 12px; font-weight: 600; }
+.ds-type { padding: 8px 0; border-bottom: 1px solid var(--op-border); }
+.menu-sheet {
+  position: absolute; inset: 0; background: rgba(10,10,10,.46);
+}
+.menu-panel {
+  position: absolute; top: 0; right: 0; width: 320px; height: 100%;
+  background: #fff; padding: 24px; box-shadow: -12px 0 40px rgba(0,0,0,.18);
+}
+.menu-panel a { display: block; padding: 12px 0; text-decoration: none; color: #111; font-weight: 600; border-bottom: 1px solid var(--op-border); }
+
+.flow {
+  width: 1600px; height: 900px; background: #151515; position: relative; overflow: hidden;
+}
+.flow-node {
+  position: absolute; width: 220px; background: #222; border: 1px solid #444; border-radius: 14px;
+  padding: 14px; color: #fff; font-size: 12px;
+}
+.flow-node b { display: block; font-size: 13px; margin-bottom: 6px; }
+.flow-node.start { border-color: var(--op-gold); }
+.flow-node.cta { border-color: var(--op-purple); background: #2a1a4a; }
+
+.telugu { font-family: var(--font-telugu); }
+.voice-card { display: flex; gap: 12px; align-items: center; }
+.avatar {
+  width: 44px; height: 44px; border-radius: 50%;
+  background: linear-gradient(135deg, var(--op-purple), var(--op-gold));
+}
+.play {
+  margin-left: auto; width: 36px; height: 36px; border-radius: 50%;
+  background: var(--op-gold); color: #1a1304; display: grid; place-items: center; font-weight: 700;
+}
+
+.hamburger { width: 22px; height: 14px; display: none; flex-direction: column; justify-content: space-between; }
+.hamburger i { display: block; width: 100%; height: 2px; background: currentColor; border-radius: 2px; }
+.mobile .nav-links, .mobile .nav .btn { display: none; }
+.mobile .hamburger { display: flex; }
+.mobile .nav { padding: 0 16px; height: 60px; }

--- a/public/ux/outpero/css/studio.css
+++ b/public/ux/outpero/css/studio.css
@@ -1,0 +1,160 @@
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body.studio {
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  background: var(--fig-bg);
+  color: var(--fig-text);
+  overflow: hidden;
+}
+
+.topbar {
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+  background: var(--fig-panel);
+  border-bottom: 1px solid var(--fig-line);
+  z-index: 20;
+  position: relative;
+}
+.topbar-left, .topbar-right, .topbar-center { display: flex; align-items: center; gap: 8px; }
+.file-name {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 10px;
+  border-radius: 6px;
+}
+.file-name:hover { background: var(--fig-panel-2); }
+.mode-switch { display: flex; background: #1e1e1e; border-radius: 8px; padding: 2px; }
+.mode-switch button {
+  appearance: none; border: 0; background: transparent; color: var(--fig-muted);
+  font: 600 12px Inter, sans-serif; padding: 6px 12px; border-radius: 6px; cursor: pointer;
+}
+.mode-switch button.active { background: var(--fig-panel-2); color: #fff; }
+.icon-btn {
+  width: 32px; height: 32px; border: 0; border-radius: 6px; background: transparent;
+  color: var(--fig-muted); cursor: pointer; display: grid; place-items: center;
+}
+.icon-btn:hover, .chip:hover { background: var(--fig-panel-2); color: #fff; }
+.chip {
+  height: 28px; padding: 0 10px; border-radius: 6px; border: 0; background: transparent;
+  color: var(--fig-muted); font: 500 12px Inter, sans-serif; cursor: pointer;
+}
+.zoom-readout { min-width: 52px; text-align: center; font-size: 12px; color: var(--fig-muted); }
+
+.layout {
+  display: grid;
+  grid-template-columns: 240px 1fr 256px;
+  height: calc(100vh - 48px);
+}
+.panel {
+  background: var(--fig-panel);
+  overflow: auto;
+  font-size: 12px;
+}
+.panel-left { border-right: 1px solid var(--fig-line); }
+.panel-right { border-left: 1px solid var(--fig-line); }
+.panel h3 {
+  margin: 0; padding: 10px 12px 6px; font-size: 11px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--fig-muted); font-weight: 600;
+}
+.pages { padding: 4px 8px 12px; }
+.page-item {
+  width: 100%; text-align: left; border: 0; background: transparent; color: #ddd;
+  padding: 8px 10px; border-radius: 6px; cursor: pointer; font: 500 12px Inter, sans-serif;
+  display: flex; justify-content: space-between; gap: 8px;
+}
+.page-item.active { background: #0d99ff22; color: #fff; }
+.page-item span { color: var(--fig-muted); font-size: 11px; }
+.layers { padding: 0 8px 16px; }
+.layer {
+  padding: 6px 10px 6px 18px; color: #cfcfcf; border-radius: 4px; cursor: pointer;
+}
+.layer.active { background: #0d99ff33; color: #fff; }
+.layer::before { content: "▭ "; opacity: .6; }
+
+.canvas-wrap {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 1px 1px, #2a2a2a 1px, transparent 0) 0 0 / 16px 16px,
+    var(--fig-canvas);
+  cursor: grab;
+}
+.canvas-wrap.panning { cursor: grabbing; }
+.canvas {
+  position: absolute;
+  transform-origin: 0 0;
+  will-change: transform;
+}
+.frame-wrap { position: absolute; }
+.frame-label {
+  position: absolute; top: -22px; left: 0; font-size: 11px; color: #9a9a9a;
+  font-weight: 500; white-space: nowrap; pointer-events: none;
+}
+.frame-wrap.selected .frame-label { color: var(--fig-blue); }
+.artboard {
+  overflow: hidden;
+  height: auto;
+  min-height: 720px;
+  box-shadow: 0 12px 40px rgba(0,0,0,.45);
+  position: relative;
+  background: #fff;
+}
+.artboard.desktop { width: 1440px; }
+.artboard.mobile { width: 390px; }
+.frame-wrap.selected .artboard { outline: 1.5px solid var(--fig-blue); outline-offset: 0; }
+body.prototype-mode .frame-wrap.selected .artboard { outline-color: var(--fig-proto); }
+body.prototype-mode .frame-wrap.selected .frame-label { color: var(--fig-proto); }
+
+.hotspot {
+  position: absolute; inset: 0; border-radius: inherit; cursor: pointer;
+}
+body.design-mode .hotspot { pointer-events: none; }
+body.prototype-mode .hotspot {
+  outline: 1px dashed transparent;
+}
+body.prototype-mode .hotspot:hover { outline-color: var(--fig-proto); background: #a259ff22; }
+
+.proto-line {
+  position: absolute; pointer-events: none; z-index: 5;
+}
+
+.inspect { padding: 8px 12px 24px; color: #ddd; }
+.inspect .row { display: flex; justify-content: space-between; gap: 8px; padding: 6px 0; border-bottom: 1px solid #3a3a3a; }
+.swatch { width: 14px; height: 14px; border-radius: 3px; border: 1px solid #666; display: inline-block; vertical-align: middle; margin-right: 6px; }
+.token { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; color: #9ad; }
+
+.hint {
+  position: absolute; left: 16px; bottom: 16px; background: #000000aa; color: #ccc;
+  padding: 8px 10px; border-radius: 8px; font-size: 11px; pointer-events: none;
+}
+
+.cover {
+  width: 1440px; min-height: 900px; background: #07070a; color: #fff;
+  display: flex; flex-direction: column; justify-content: space-between;
+  padding: 80px;
+  position: relative; overflow: hidden;
+}
+.cover::before {
+  content: ""; position: absolute; inset: -20%;
+  background:
+    radial-gradient(600px 400px at 20% 20%, rgba(122,80,220,.35), transparent 60%),
+    radial-gradient(500px 360px at 80% 70%, rgba(226,184,90,.18), transparent 60%);
+}
+.cover > * { position: relative; }
+.cover .kicker { letter-spacing: .28em; font-size: 12px; color: var(--op-gold); text-transform: uppercase; }
+.cover h1 { font-family: var(--font-display); font-size: 72px; line-height: 1.05; margin: 18px 0 12px; font-weight: 700; }
+.cover p { max-width: 640px; color: #c9c9c9; font-size: 18px; line-height: 1.5; }
+.cover-meta { display: flex; gap: 40px; color: #aaa; font-size: 13px; }
+.cover-meta b { display: block; color: #fff; font-size: 14px; margin-bottom: 4px; }
+.thumbs { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; margin-top: 40px; }
+.thumb {
+  height: 120px; border-radius: 12px; padding: 12px; display: flex; flex-direction: column; justify-content: flex-end;
+  border: 1px solid #ffffff14;
+}
+.thumb.light { background: linear-gradient(180deg, #fff, #faf8f5); color: #111; }
+.thumb.dark { background: linear-gradient(180deg, #1a1a1a, #050505); color: #fff; }
+.thumb b { font-size: 13px; }
+.thumb span { font-size: 11px; opacity: .65; }

--- a/public/ux/outpero/css/tokens.css
+++ b/public/ux/outpero/css/tokens.css
@@ -1,0 +1,46 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600;700;800&family=Noto+Sans+Telugu:wght@500;700&display=swap");
+
+:root {
+  --op-cream: #faf8f5;
+  --op-cream-2: #f3efe8;
+  --op-ink: #0a0a0a;
+  --op-ink-2: #18181b;
+  --op-muted: #737373;
+  --op-muted-2: #525252;
+  --op-purple: #7a50dc;
+  --op-purple-deep: #673fc4;
+  --op-purple-soft: #ac4bff;
+  --op-indigo: #818cf8;
+  --op-gold: #e2b85a;
+  --op-gold-dim: #c99b3c;
+  --op-green: #149e6a;
+  --op-mint: #00e699;
+  --op-white: #ffffff;
+  --op-deep: #050505;
+  --op-navy: #0a0a0a;
+  --op-glass: rgba(255, 255, 255, 0.72);
+  --op-glass-dark: rgba(15, 15, 15, 0.66);
+  --op-border: rgba(0, 0, 0, 0.08);
+  --op-border-dark: rgba(255, 255, 255, 0.1);
+  --font-display: "Poppins", sans-serif;
+  --font-body: "Inter", sans-serif;
+  --font-telugu: "Noto Sans Telugu", sans-serif;
+  --r-sm: 8px;
+  --r-md: 12px;
+  --r-lg: 16px;
+  --r-xl: 24px;
+  --r-pill: 999px;
+  --shadow-card: 0 8px 32px rgba(79, 70, 229, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.05);
+  --shadow-glow: 0 12px 40px rgba(122, 80, 220, 0.28);
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+
+  --fig-bg: #1e1e1e;
+  --fig-panel: #2c2c2c;
+  --fig-panel-2: #383838;
+  --fig-line: #444444;
+  --fig-text: #ffffff;
+  --fig-muted: #b3b3b3;
+  --fig-blue: #0d99ff;
+  --fig-proto: #a259ff;
+  --fig-canvas: #1e1e1e;
+}

--- a/public/ux/outpero/favicon.svg
+++ b/public/ux/outpero/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#050505"/>
+  <circle cx="16" cy="16" r="8" fill="none" stroke="#7A50DC" stroke-width="2"/>
+  <circle cx="16" cy="16" r="3" fill="#E2B85A"/>
+</svg>

--- a/public/ux/outpero/index.html
+++ b/public/ux/outpero/index.html
@@ -1,0 +1,975 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" href="./favicon.svg" />
+  <link rel="stylesheet" href="./css/tokens.css" />
+  <link rel="stylesheet" href="./css/studio.css" />
+  <link rel="stylesheet" href="./css/screens.css" />
+</head>
+<body class="studio design-mode">
+  <header class="topbar">
+    <div class="topbar-left">
+      <strong class="file-name">OUTPERO UX</strong>
+      <span class="chip">Draft</span>
+    </div>
+    <div class="topbar-center">
+      <div class="mode-switch">
+        <button class="active" data-mode="design">Design</button>
+        <button data-mode="prototype">Prototype</button>
+        <button data-mode="inspect">Inspect</button>
+      </div>
+    </div>
+    <div class="topbar-right">
+      <button class="chip" id="zoomOut">−</button>
+      <span class="zoom-readout" id="zoomReadout">35%</span>
+      <button class="chip" id="zoomIn">+</button>
+      <button class="chip" id="zoomFit">Fit</button>
+    </div>
+  </header>
+  <div class="layout">
+    <aside class="panel panel-left">
+      <h3>Pages</h3>
+      <div class="pages"><button class="page-item" data-page="cover">Cover<span>1</span></button><button class="page-item" data-page="ds">Design system<span>1</span></button><button class="page-item" data-page="home">Home<span>2</span></button><button class="page-item" data-page="solutions">Solutions<span>2</span></button><button class="page-item" data-page="contact">Contact<span>2</span></button><button class="page-item" data-page="about">About<span>2</span></button><button class="page-item" data-page="systems">Revenue systems<span>2</span></button><button class="page-item" data-page="employee">Hire AI Employee<span>2</span></button><button class="page-item" data-page="pricing">Pricing<span>2</span></button><button class="page-item" data-page="voice">Voice agents<span>2</span></button><button class="page-item" data-page="compare">Compare + Blog<span>3</span></button><button class="page-item" data-page="menu">Mobile menu<span>1</span></button><button class="page-item" data-page="flows">User flows<span>1</span></button></div>
+      <h3>Layers</h3>
+      <div class="layers" id="layers"></div>
+    </aside>
+    <main class="canvas-wrap" id="canvasWrap">
+      <div class="canvas" id="canvas"><div class="canvas-page" data-page="cover" hidden>
+    <div class="frame-wrap" data-frame="cover-desktop" data-page-owner="cover" style="left:80px;top:80px">
+      <div class="frame-label">Cover</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="cover">
+      <div>
+        <div class="kicker">UX file · Desktop + Mobile</div>
+        <h1>OUTPERO<br>experience design</h1>
+        <p>High-fidelity artboards reverse-engineered from outpero.com. Agency light for conversion. Product dark for the AI employee. Switch to Prototype and click CTAs to walk the paths.</p>
+        <div class="thumbs"><div class="thumb light"><b>Home</b><span>Agency · 1440 / 390</span></div><div class="thumb light"><b>Solutions</b><span>19 SKUs · filters</span></div><div class="thumb light"><b>Contact</b><span>Audit form</span></div><div class="thumb dark"><b>AI Employee</b><span>Product dark</span></div><div class="thumb dark"><b>Pricing</b><span>₹1899 + usage</span></div><div class="thumb dark"><b>Voice</b><span>Telugu samples</span></div></div>
+      </div>
+      <div class="cover-meta">
+        <div><b>Artboards</b>13 pages · 23 frames</div>
+        <div><b>Breakpoints</b>1440 desktop · 390 mobile</div>
+        <div><b>Themes</b>Agency cream · Product cinematic</div>
+        <div><b>Primary CTA</b>Book Free Audit → Contact</div>
+      </div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="ds" hidden>
+    <div class="frame-wrap" data-frame="ds-desktop" data-page-owner="ds" style="left:80px;top:80px">
+      <div class="frame-label">Design system / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ds-wrap">
+      <div class="kicker">Foundation</div>
+      <h1 class="display" style="font-size:48px">OUTPERO design system</h1>
+      <p class="lede">Two themes, one brand. Agency light for trust and audits. Product dark for hiring the AI employee.</p>
+      <h2 style="margin-top:36px">Color</h2>
+      <div class="ds-grid"><div class="ds-color" style="background:#FAF8F5;color:#111">Cream / Agency bg<br>#FAF8F5</div><div class="ds-color" style="background:#050505;color:#fff">Deep / Product bg<br>#050505</div><div class="ds-color" style="background:#7A50DC;color:#fff">Purple / Primary<br>#7A50DC</div><div class="ds-color" style="background:#673FC4;color:#fff">Purple deep<br>#673FC4</div><div class="ds-color" style="background:#E2B85A;color:#1a1304">Gold / Accent<br>#E2B85A</div><div class="ds-color" style="background:#818CF8;color:#111">Indigo glow<br>#818CF8</div><div class="ds-color" style="background:#0A0A0A;color:#fff">Ink<br>#0A0A0A</div><div class="ds-color" style="background:#737373;color:#fff">Muted<br>#737373</div></div>
+      <h2 style="margin-top:36px">Type</h2>
+      <div class="ds-type" style="font-family:Poppins,sans-serif;font-size:40px;font-weight:700">Poppins / Display</div>
+      <div class="ds-type" style="font-size:18px">Inter / Body — 16px / 1.5 — minimum 16px on mobile inputs</div>
+      <div class="ds-type telugu" style="font-size:28px">Noto Sans Telugu / Native voice UI</div>
+      <h2 style="margin-top:36px">Components</h2>
+      <div class="cta-row">
+        <a class="btn btn-primary">Primary CTA</a>
+        <a class="btn btn-gold">Product CTA</a>
+        <a class="btn btn-ghost">Secondary</a>
+      </div>
+      <div class="grid-3" style="margin-top:20px">
+        <div class="card"><div class="cat">Card</div><h3>Glass surface</h3><p>20px radius, 1px border, blur.</p></div>
+        <div class="card"><span class="flagship">FLAGSHIP</span><h3>Highlight</h3><p>Gold ring for recommended plan.</p></div>
+        <div class="card"><label style="font-size:12px;font-weight:600">Input</label><input style="width:100%;margin-top:8px;padding:12px;border-radius:12px;border:1px solid #0002" placeholder="16px text, 44px tall"></div>
+      </div>
+      <h2 style="margin-top:36px">Breakpoints</h2>
+      <p>390 mobile · 768 tablet · 1024 laptop · 1440 desktop · 1920 wall</p>
+      <p>Touch targets ≥ 44px. Nav collapses under 768. Grids 3→1. Process 4→stack. Footer 4→1.</p>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="home" hidden>
+    <div class="frame-wrap" data-frame="home-desktop" data-page-owner="home" style="left:80px;top:80px">
+      <div class="frame-label">Home / Desktop 1440</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-agency desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class="active hotspot" data-go="home">Home</a><a class=" hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class=" hotspot" data-go="voice">AI Voice Agents</a><a class=" hotspot" data-go="solutions">Solutions</a><a class=" hotspot" data-go="about">About</a><a class=" hotspot" data-go="contact">Contact</a></nav><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></header>
+      <section class="hero">
+        <div class="split">
+          <div>
+            <div class="kicker">Systems that outperform</div>
+            <h1 class="display">Your business is <span class="grad">leaking</span> revenue. We seal it.</h1>
+            <p class="lede">AI automations, voice agents, and web solutions — engineered around your outcomes, not our deliverables.</p>
+            <div class="cta-row">
+              <a class="btn btn-primary hotspot" data-go="contact">Book a Free Audit</a>
+              <a class="btn btn-ghost hotspot" data-go="systems">See Our Systems</a>
+            </div>
+          </div>
+          <div class="diagram"><svg width="100%" height="100%" style="position:absolute;inset:0"><g stroke="#7a50dc55" stroke-width="1.5" fill="none" stroke-dasharray="4 6"><line x1="50%" y1="50%" x2="22%" y2="28%"/><line x1="50%" y1="50%" x2="78%" y2="24%"/><line x1="50%" y1="50%" x2="18%" y2="68%"/><line x1="50%" y1="50%" x2="82%" y2="62%"/><line x1="50%" y1="50%" x2="50%" y2="86%"/><line x1="50%" y1="50%" x2="72%" y2="80%"/></g></svg><div class="node core" style="left:50%;top:50%">YOUR<br>BUSINESS</div><div class="node " style="left:22%;top:28%">Leads</div><div class="node " style="left:78%;top:24%">Follow-up</div><div class="node " style="left:18%;top:68%">Bookings</div><div class="node " style="left:82%;top:62%">24/7 Calls</div><div class="node " style="left:50%;top:86%">WhatsApp</div><div class="node leak" style="left:72%;top:80%">Leaking Revenue</div></div>
+        </div>
+      </section>
+      <div class="marquee"><span>Real Estate</span><span>Clinics & Healthcare</span><span>Coaches & Consultants</span><span>D2C Brands</span><span>Legal Firms</span><span>E-commerce</span><span>SaaS Startups</span></div>
+      <section class="section">
+        <h2 class="display">You're doing everything right. But still losing.</h2>
+        <div class="grid-3" style="margin-top:28px">
+          <div class="card"><div class="num">01</div><h3>Leads Going Cold</h3><p>78% of customers buy from whoever responds first. By the time you call back, the deal is gone.</p></div>
+          <div class="card"><div class="num">02</div><h3>Too Much Manual Work</h3><p>Teams burn 20–40 hours a week on data entry, scheduling, and reports instead of revenue.</p></div>
+          <div class="card"><div class="num">03</div><h3>Websites That Don't Convert</h3><p>Traffic lands, looks around, and leaves. No system to capture and qualify visitors.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Revenue systems</div>
+        <h2 class="display">Three systems. Each solves one expensive problem.</h2>
+        <div class="grid-3" style="margin-top:28px">
+          <div class="card hotspot" data-go="systems"><div class="num">System 1</div><h3>Revenue Capture</h3><p>Contact, qualify, and book leads in seconds.</p><ul class="checks"><li>AI Voice Agent (24/7)</li><li>WhatsApp & SMS Bot</li><li>Instant CRM Sync</li></ul><div class="price">From ₹60,000</div></div>
+          <div class="card hotspot" data-go="systems" style="box-shadow:0 0 0 1px #e2b85a, var(--shadow-card)"><span class="flagship">FLAGSHIP</span><div class="num">System 2</div><h3>Ops Efficiency</h3><p>Eliminate 20–40 hours of manual tasks weekly.</p><ul class="checks"><li>Workflow Process Mapping</li><li>3–5 Core Automations</li><li>Custom n8n/Make Logic</li></ul><div class="price">From ₹1,00,000</div></div>
+          <div class="card hotspot" data-go="systems"><div class="num">System 3</div><h3>Web Capture</h3><p>Turn passive visitors into qualified leads.</p><ul class="checks"><li>High-Converting Landing Pages</li><li>Frictionless Lead Capture</li><li>Automated WhatsApp Triggers</li></ul><div class="price">From ₹50,000</div></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Our process</div>
+        <h2 class="display">From first call to live system. In 2 weeks.</h2>
+        <div class="steps" style="margin-top:28px">
+          <div class="card"><div class="step-index">01</div><h3>We understand</h3><p>30-minute call. Find where money is leaking.</p></div>
+          <div class="card"><div class="step-index">02</div><h3>Scope & price</h3><p>Exact deliverables, timeline, and cost in writing.</p></div>
+          <div class="card"><div class="step-index">03</div><h3>We build it</h3><p>Full build and setup. You stay on the business.</p></div>
+          <div class="card"><div class="step-index">04</div><h3>Goes live</h3><p>Hours saved and revenue retained within 30 days.</p></div>
+        </div>
+        <div class="grid-4" style="margin-top:28px">
+          <div class="stat"><b>0 sec</b><span>Lead response</span></div>
+          <div class="stat"><b>0 hrs</b><span>Manual work gone</span></div>
+          <div class="stat"><b>0x</b><span>Conversion lift</span></div>
+          <div class="stat"><b>Zero</b><span>Tech headache</span></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Individual solutions</div>
+        <h2 class="display">Not ready for a full system? Start with one.</h2>
+        <p class="lede">19 pre-built solutions. Starting from ₹14,999.</p>
+        <div class="grid-2" style="margin-top:20px">
+          <div class="card hotspot" data-go="solutions"><div class="cat">AI & Automation</div><h3>Instant Lead Follow-Up</h3><p>WhatsApp + email the second a form is submitted.</p></div>
+          <div class="card hotspot" data-go="voice"><div class="cat">AI Voice</div><h3>Inbound AI Receptionist</h3><p>Answers every call, routes, and books 24/7.</p></div>
+          <div class="card hotspot" data-go="solutions"><div class="cat">Web</div><h3>High-Converting Landing Pages</h3><p>Single-page funnels built to capture and book.</p></div>
+          <div class="card hotspot" data-go="solutions"><div class="cat">AI & Automation</div><h3>Appointment Booking Bot</h3><p>Prospects book themselves. Zero calendar ping-pong.</p></div>
+        </div>
+        <div class="cta-row"><a class="btn btn-ghost hotspot" data-go="solutions">Explore all 19 solutions</a></div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Why work with us?</h2>
+        <div class="grid-2" style="margin-top:20px">
+          <div class="card"><h3>Business first, tech second</h3><p>If it will not save time or make money, we will not recommend it.</p></div>
+          <div class="card"><h3>Clear, measurable ROI</h3><p>Every system is measured by hours saved and revenue generated.</p></div>
+          <div class="card"><h3>Fast deployment</h3><p>Biggest bottleneck first. Live in weeks, not months.</p></div>
+          <div class="card"><h3>Zero technical headaches</h3><p>We build, integrate, and maintain. You get a working system.</p></div>
+        </div>
+      </section>
+      <section class="section faq" style="padding-top:0">
+        <h2 class="display">Clear answers. No jargon.</h2>
+        <details open><summary>What exactly do you build?</summary><p>Voice agents, WhatsApp/CRM automations, and conversion websites — scoped to one revenue leak at a time.</p></details>
+        <details><summary>Will I need to replace my existing software?</summary><p>No. We wire into the tools you already use.</p></details>
+        <details><summary>How long does implementation take?</summary><p>Most systems go live in two weeks after scope is signed.</p></details>
+        <details><summary>How do you charge?</summary><p>Fixed-scope agency builds from ₹14,999, or hire an AI employee at ₹1,899 / 30 days plus usage.</p></details>
+      </section>
+      <div class="cta-band">
+        <h2>Your revenue leak has a fix. Let's find it.</h2>
+        <p>Book a free 30-minute strategy call. No obligation. No pitch. Just clarity.</p>
+        <div class="cta-row">
+          <a class="btn btn-gold hotspot" data-go="contact">Book Free Audit →</a>
+          <a class="btn btn-ghost hotspot" data-go="solutions" style="color:#fff;box-shadow:inset 0 0 0 1px #fff6">Explore the Solutions →</a>
+        </div>
+      </div>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="home-mobile" data-page-owner="home" style="left:1600px;top:80px">
+      <div class="frame-label">Home / Mobile 390</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-agency mobile">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <section class="hero">
+        <div class="split">
+          <div>
+            <div class="kicker">Systems that outperform</div>
+            <h1 class="display">Your business is <span class="grad">leaking</span> revenue. We seal it.</h1>
+            <p class="lede">AI automations, voice agents, and web solutions — engineered around your outcomes, not our deliverables.</p>
+            <div class="cta-row">
+              <a class="btn btn-primary hotspot" data-go="contact">Book a Free Audit</a>
+              <a class="btn btn-ghost hotspot" data-go="systems">See Our Systems</a>
+            </div>
+          </div>
+          <div class="diagram"><svg width="100%" height="100%" style="position:absolute;inset:0"><g stroke="#7a50dc55" stroke-width="1.5" fill="none" stroke-dasharray="4 6"><line x1="50%" y1="50%" x2="22%" y2="28%"/><line x1="50%" y1="50%" x2="78%" y2="24%"/><line x1="50%" y1="50%" x2="18%" y2="68%"/><line x1="50%" y1="50%" x2="82%" y2="62%"/><line x1="50%" y1="50%" x2="50%" y2="86%"/><line x1="50%" y1="50%" x2="72%" y2="80%"/></g></svg><div class="node core" style="left:50%;top:50%">YOUR<br>BUSINESS</div><div class="node " style="left:22%;top:28%">Leads</div><div class="node " style="left:78%;top:24%">Follow-up</div><div class="node " style="left:18%;top:68%">Bookings</div><div class="node " style="left:82%;top:62%">24/7 Calls</div><div class="node " style="left:50%;top:86%">WhatsApp</div><div class="node leak" style="left:72%;top:80%">Leaking Revenue</div></div>
+        </div>
+      </section>
+      <div class="marquee"><span>Real Estate</span><span>Clinics & Healthcare</span><span>Coaches & Consultants</span><span>D2C Brands</span><span>Legal Firms</span><span>E-commerce</span><span>SaaS Startups</span></div>
+      <section class="section">
+        <h2 class="display">You're doing everything right. But still losing.</h2>
+        <div class="grid-3" style="margin-top:28px">
+          <div class="card"><div class="num">01</div><h3>Leads Going Cold</h3><p>78% of customers buy from whoever responds first. By the time you call back, the deal is gone.</p></div>
+          <div class="card"><div class="num">02</div><h3>Too Much Manual Work</h3><p>Teams burn 20–40 hours a week on data entry, scheduling, and reports instead of revenue.</p></div>
+          <div class="card"><div class="num">03</div><h3>Websites That Don't Convert</h3><p>Traffic lands, looks around, and leaves. No system to capture and qualify visitors.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Revenue systems</div>
+        <h2 class="display">Three systems. Each solves one expensive problem.</h2>
+        <div class="grid-3" style="margin-top:28px">
+          <div class="card hotspot" data-go="systems"><div class="num">System 1</div><h3>Revenue Capture</h3><p>Contact, qualify, and book leads in seconds.</p><ul class="checks"><li>AI Voice Agent (24/7)</li><li>WhatsApp & SMS Bot</li><li>Instant CRM Sync</li></ul><div class="price">From ₹60,000</div></div>
+          <div class="card hotspot" data-go="systems" style="box-shadow:0 0 0 1px #e2b85a, var(--shadow-card)"><span class="flagship">FLAGSHIP</span><div class="num">System 2</div><h3>Ops Efficiency</h3><p>Eliminate 20–40 hours of manual tasks weekly.</p><ul class="checks"><li>Workflow Process Mapping</li><li>3–5 Core Automations</li><li>Custom n8n/Make Logic</li></ul><div class="price">From ₹1,00,000</div></div>
+          <div class="card hotspot" data-go="systems"><div class="num">System 3</div><h3>Web Capture</h3><p>Turn passive visitors into qualified leads.</p><ul class="checks"><li>High-Converting Landing Pages</li><li>Frictionless Lead Capture</li><li>Automated WhatsApp Triggers</li></ul><div class="price">From ₹50,000</div></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Our process</div>
+        <h2 class="display">From first call to live system. In 2 weeks.</h2>
+        <div class="steps" style="margin-top:28px">
+          <div class="card"><div class="step-index">01</div><h3>We understand</h3><p>30-minute call. Find where money is leaking.</p></div>
+          <div class="card"><div class="step-index">02</div><h3>Scope & price</h3><p>Exact deliverables, timeline, and cost in writing.</p></div>
+          <div class="card"><div class="step-index">03</div><h3>We build it</h3><p>Full build and setup. You stay on the business.</p></div>
+          <div class="card"><div class="step-index">04</div><h3>Goes live</h3><p>Hours saved and revenue retained within 30 days.</p></div>
+        </div>
+        <div class="grid-4" style="margin-top:28px">
+          <div class="stat"><b>0 sec</b><span>Lead response</span></div>
+          <div class="stat"><b>0 hrs</b><span>Manual work gone</span></div>
+          <div class="stat"><b>0x</b><span>Conversion lift</span></div>
+          <div class="stat"><b>Zero</b><span>Tech headache</span></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Individual solutions</div>
+        <h2 class="display">Not ready for a full system? Start with one.</h2>
+        <p class="lede">19 pre-built solutions. Starting from ₹14,999.</p>
+        <div class="grid-2" style="margin-top:20px">
+          <div class="card hotspot" data-go="solutions"><div class="cat">AI & Automation</div><h3>Instant Lead Follow-Up</h3><p>WhatsApp + email the second a form is submitted.</p></div>
+          <div class="card hotspot" data-go="voice"><div class="cat">AI Voice</div><h3>Inbound AI Receptionist</h3><p>Answers every call, routes, and books 24/7.</p></div>
+          <div class="card hotspot" data-go="solutions"><div class="cat">Web</div><h3>High-Converting Landing Pages</h3><p>Single-page funnels built to capture and book.</p></div>
+          <div class="card hotspot" data-go="solutions"><div class="cat">AI & Automation</div><h3>Appointment Booking Bot</h3><p>Prospects book themselves. Zero calendar ping-pong.</p></div>
+        </div>
+        <div class="cta-row"><a class="btn btn-ghost hotspot" data-go="solutions">Explore all 19 solutions</a></div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Why work with us?</h2>
+        <div class="grid-2" style="margin-top:20px">
+          <div class="card"><h3>Business first, tech second</h3><p>If it will not save time or make money, we will not recommend it.</p></div>
+          <div class="card"><h3>Clear, measurable ROI</h3><p>Every system is measured by hours saved and revenue generated.</p></div>
+          <div class="card"><h3>Fast deployment</h3><p>Biggest bottleneck first. Live in weeks, not months.</p></div>
+          <div class="card"><h3>Zero technical headaches</h3><p>We build, integrate, and maintain. You get a working system.</p></div>
+        </div>
+      </section>
+      <section class="section faq" style="padding-top:0">
+        <h2 class="display">Clear answers. No jargon.</h2>
+        <details open><summary>What exactly do you build?</summary><p>Voice agents, WhatsApp/CRM automations, and conversion websites — scoped to one revenue leak at a time.</p></details>
+        <details><summary>Will I need to replace my existing software?</summary><p>No. We wire into the tools you already use.</p></details>
+        <details><summary>How long does implementation take?</summary><p>Most systems go live in two weeks after scope is signed.</p></details>
+        <details><summary>How do you charge?</summary><p>Fixed-scope agency builds from ₹14,999, or hire an AI employee at ₹1,899 / 30 days plus usage.</p></details>
+      </section>
+      <div class="cta-band">
+        <h2>Your revenue leak has a fix. Let's find it.</h2>
+        <p>Book a free 30-minute strategy call. No obligation. No pitch. Just clarity.</p>
+        <div class="cta-row">
+          <a class="btn btn-gold hotspot" data-go="contact">Book Free Audit →</a>
+          <a class="btn btn-ghost hotspot" data-go="solutions" style="color:#fff;box-shadow:inset 0 0 0 1px #fff6">Explore the Solutions →</a>
+        </div>
+      </div>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="solutions" hidden>
+    <div class="frame-wrap" data-frame="sol-desktop" data-page-owner="solutions" style="left:80px;top:80px">
+      <div class="frame-label">Solutions / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-agency desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class=" hotspot" data-go="home">Home</a><a class=" hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class=" hotspot" data-go="voice">AI Voice Agents</a><a class="active hotspot" data-go="solutions">Solutions</a><a class=" hotspot" data-go="about">About</a><a class=" hotspot" data-go="contact">Contact</a></nav><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></header>
+      <section class="hero" style="text-align:center">
+        <div class="kicker">Solutions</div>
+        <h1 class="display" style="max-width:900px;margin-left:auto;margin-right:auto">Drop-in solutions for immediate ROI.</h1>
+        <p class="lede" style="margin-left:auto;margin-right:auto">19 standalone solutions. Each one targets one specific problem. Starting from ₹14,999.</p>
+        <div class="cta-row" style="justify-content:center"><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></div>
+        <div class="chips" style="justify-content:center">
+          <span class="chip-filter active">All</span>
+          <span class="chip-filter">AI & Automation</span>
+          <span class="chip-filter">AI Voice</span>
+          <span class="chip-filter">Web</span>
+          <span class="chip-filter">Audit & Strategy</span>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0"><div class="sol-item"><div><div class="cat">AI & Automation</div><h3 style="margin:4px 0 4px;font-size:16px">WhatsApp Business Automation</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">End-to-end automated WhatsApp interactions.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">AI & Automation</div><h3 style="margin:4px 0 4px;font-size:16px">AI Lead Qualification</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Automatic scoring and filtering for every lead.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">AI & Automation</div><h3 style="margin:4px 0 4px;font-size:16px">Appointment Booking Automation</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Zero-touch scheduling and reminders.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">AI Voice</div><h3 style="margin:4px 0 4px;font-size:16px">Inbound AI Voice Agent</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">24/7 intelligent answering and lead routing.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">AI Voice</div><h3 style="margin:4px 0 4px;font-size:16px">Outbound AI Voice Agent</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Scalable proactive calling and engagement.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">Web</div><h3 style="margin:4px 0 4px;font-size:16px">Landing Page</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">High-velocity standalone pages for campaigns.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">Web</div><h3 style="margin:4px 0 4px;font-size:16px">Website + Lead Pipeline</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Site fully wired into automated CRM follow-ups.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">Audit & Strategy</div><h3 style="margin:4px 0 4px;font-size:16px">Business Automation Audit</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Map operational leaks and ROI fixes.</p></div><span>⌄</span></div>
+        <p class="lede" style="margin-top:18px;font-size:13px">All fees cover build and management. Platforms billed separately at cost.</p>
+      </section>
+      <div class="cta-band">
+        <h2>Need a complete transformation?</h2>
+        <p>Stop stitching tools together. Explore the three revenue systems.</p>
+        <a class="btn btn-gold hotspot" data-go="systems">Explore Revenue Systems</a>
+      </div>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="sol-mobile" data-page-owner="solutions" style="left:1600px;top:80px">
+      <div class="frame-label">Solutions / Mobile</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-agency mobile">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <section class="hero" style="text-align:center">
+        <div class="kicker">Solutions</div>
+        <h1 class="display" style="max-width:900px;margin-left:auto;margin-right:auto">Drop-in solutions for immediate ROI.</h1>
+        <p class="lede" style="margin-left:auto;margin-right:auto">19 standalone solutions. Each one targets one specific problem. Starting from ₹14,999.</p>
+        <div class="cta-row" style="justify-content:center"><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></div>
+        <div class="chips" style="justify-content:center">
+          <span class="chip-filter active">All</span>
+          <span class="chip-filter">AI & Automation</span>
+          <span class="chip-filter">AI Voice</span>
+          <span class="chip-filter">Web</span>
+          <span class="chip-filter">Audit & Strategy</span>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0"><div class="sol-item"><div><div class="cat">AI & Automation</div><h3 style="margin:4px 0 4px;font-size:16px">WhatsApp Business Automation</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">End-to-end automated WhatsApp interactions.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">AI & Automation</div><h3 style="margin:4px 0 4px;font-size:16px">AI Lead Qualification</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Automatic scoring and filtering for every lead.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">AI & Automation</div><h3 style="margin:4px 0 4px;font-size:16px">Appointment Booking Automation</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Zero-touch scheduling and reminders.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">AI Voice</div><h3 style="margin:4px 0 4px;font-size:16px">Inbound AI Voice Agent</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">24/7 intelligent answering and lead routing.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">AI Voice</div><h3 style="margin:4px 0 4px;font-size:16px">Outbound AI Voice Agent</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Scalable proactive calling and engagement.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">Web</div><h3 style="margin:4px 0 4px;font-size:16px">Landing Page</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">High-velocity standalone pages for campaigns.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">Web</div><h3 style="margin:4px 0 4px;font-size:16px">Website + Lead Pipeline</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Site fully wired into automated CRM follow-ups.</p></div><span>⌄</span></div><div class="sol-item"><div><div class="cat">Audit & Strategy</div><h3 style="margin:4px 0 4px;font-size:16px">Business Automation Audit</h3><p style="margin:0;color:var(--op-muted-2);font-size:13px">Map operational leaks and ROI fixes.</p></div><span>⌄</span></div>
+        <p class="lede" style="margin-top:18px;font-size:13px">All fees cover build and management. Platforms billed separately at cost.</p>
+      </section>
+      <div class="cta-band">
+        <h2>Need a complete transformation?</h2>
+        <p>Stop stitching tools together. Explore the three revenue systems.</p>
+        <a class="btn btn-gold hotspot" data-go="systems">Explore Revenue Systems</a>
+      </div>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="contact" hidden>
+    <div class="frame-wrap" data-frame="con-desktop" data-page-owner="contact" style="left:80px;top:80px">
+      <div class="frame-label">Contact / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-agency desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class=" hotspot" data-go="home">Home</a><a class=" hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class=" hotspot" data-go="voice">AI Voice Agents</a><a class=" hotspot" data-go="solutions">Solutions</a><a class=" hotspot" data-go="about">About</a><a class="active hotspot" data-go="contact">Contact</a></nav><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></header>
+      <section class="hero">
+        <div class="split">
+          <div>
+            <div class="kicker">Contact</div>
+            <h1 class="display">Book your free business audit.</h1>
+            <p class="lede">30 minutes. We'll show you exactly where you're losing money and what to build first.</p>
+            <div class="card" style="margin-top:24px">
+              <b>What to expect</b>
+              <ul class="checks">
+                <li>Review current workflows or website</li>
+                <li>Identify 2–3 immediate quick wins</li>
+                <li>Map the highest-ROI system</li>
+                <li>Give a written estimate</li>
+              </ul>
+              <p style="margin-top:16px;font-size:13px">We respond within 24 hours · hello@outpero.com</p>
+            </div>
+            <a class="btn btn-ghost hotspot" data-go="voice" style="margin-top:16px">Looking for a voice agent? Explore →</a>
+          </div>
+          
+      <form class="form card">
+        <div><label>Name *</label><input placeholder="Your full name"></div>
+        <div><label>Business Name *</label><input placeholder="Your company name"></div>
+        <div><label>Email *</label><input type="email" placeholder="you@company.com"></div>
+        <div><label>Phone (WhatsApp preferred) *</label><input type="tel" placeholder="+91 98765 43210"></div>
+        <div><label>Business Type *</label><select><option>Real Estate</option><option>Clinic</option><option>Coaching</option><option>D2C</option><option>Other</option></select></div>
+        <div><label>Business Size *</label><select><option>Solo (1 person)</option><option>2-10 employees</option><option>11-50 employees</option></select></div>
+        <div><label>Biggest Challenge *</label><textarea placeholder="What is the biggest operational or growth challenge right now?"></textarea></div>
+        <button class="btn btn-primary btn-block" type="button">Book My Free Audit</button>
+      </form>
+    
+        </div>
+      </section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="con-mobile" data-page-owner="contact" style="left:1600px;top:80px">
+      <div class="frame-label">Contact / Mobile</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-agency mobile">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <section class="hero">
+        <div class="split">
+          <div>
+            <div class="kicker">Contact</div>
+            <h1 class="display">Book your free business audit.</h1>
+            <p class="lede">30 minutes. We'll show you exactly where you're losing money and what to build first.</p>
+            <div class="card" style="margin-top:24px">
+              <b>What to expect</b>
+              <ul class="checks">
+                <li>Review current workflows or website</li>
+                <li>Identify 2–3 immediate quick wins</li>
+                <li>Map the highest-ROI system</li>
+                <li>Give a written estimate</li>
+              </ul>
+              <p style="margin-top:16px;font-size:13px">We respond within 24 hours · hello@outpero.com</p>
+            </div>
+            <a class="btn btn-ghost hotspot" data-go="voice" style="margin-top:16px">Looking for a voice agent? Explore →</a>
+          </div>
+          
+      <form class="form card">
+        <div><label>Name *</label><input placeholder="Your full name"></div>
+        <div><label>Business Name *</label><input placeholder="Your company name"></div>
+        <div><label>Email *</label><input type="email" placeholder="you@company.com"></div>
+        <div><label>Phone (WhatsApp preferred) *</label><input type="tel" placeholder="+91 98765 43210"></div>
+        <div><label>Business Type *</label><select><option>Real Estate</option><option>Clinic</option><option>Coaching</option><option>D2C</option><option>Other</option></select></div>
+        <div><label>Business Size *</label><select><option>Solo (1 person)</option><option>2-10 employees</option><option>11-50 employees</option></select></div>
+        <div><label>Biggest Challenge *</label><textarea placeholder="What is the biggest operational or growth challenge right now?"></textarea></div>
+        <button class="btn btn-primary btn-block" type="button">Book My Free Audit</button>
+      </form>
+    
+        </div>
+      </section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="about" hidden>
+    <div class="frame-wrap" data-frame="about-desktop" data-page-owner="about" style="left:80px;top:80px">
+      <div class="frame-label">About / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-agency desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class=" hotspot" data-go="home">Home</a><a class=" hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class=" hotspot" data-go="voice">AI Voice Agents</a><a class=" hotspot" data-go="solutions">Solutions</a><a class="active hotspot" data-go="about">About</a><a class=" hotspot" data-go="contact">Contact</a></nav><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></header>
+      <section class="hero">
+        <h1 class="display">We understand business first.<br>Technology second.</h1>
+        <p class="lede">Most agencies sell tools, not outcomes. OUTPERO starts with the leak, then engineers the system that seals it.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Philosophy</div>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card"><h3>Outcome-first</h3><p>Measured by the result it creates for your business.</p></div>
+          <div class="card"><h3>Business audit always</h3><p>We map workflows before writing a line of code.</p></div>
+          <div class="card"><h3>ROI tracked</h3><p>Time saved. Revenue captured. Costs cut.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">What we build</div>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card hotspot" data-go="systems"><h3>Revenue Capture</h3><p>Instant lead response, qualification, and booking — 24/7.</p></div>
+          <div class="card hotspot" data-go="systems"><h3>Ops Efficiency</h3><p>Eliminate 20–40 hours of manual work every week.</p></div>
+          <div class="card hotspot" data-go="systems"><h3>Digital Salesman</h3><p>Websites that convert, wired to automated pipelines.</p></div>
+        </div>
+      </section>
+      <div class="cta-band"><h2>Have a specific problem?</h2><p>Reach the founder at vatsal@outpero.com or book an audit.</p><a class="btn btn-gold hotspot" data-go="contact">Book Free Audit</a></div>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="about-mobile" data-page-owner="about" style="left:1600px;top:80px">
+      <div class="frame-label">About / Mobile</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-agency mobile">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <section class="hero">
+        <h1 class="display">We understand business first.<br>Technology second.</h1>
+        <p class="lede">Most agencies sell tools, not outcomes. OUTPERO starts with the leak, then engineers the system that seals it.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Philosophy</div>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card"><h3>Outcome-first</h3><p>Measured by the result it creates for your business.</p></div>
+          <div class="card"><h3>Business audit always</h3><p>We map workflows before writing a line of code.</p></div>
+          <div class="card"><h3>ROI tracked</h3><p>Time saved. Revenue captured. Costs cut.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">What we build</div>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card hotspot" data-go="systems"><h3>Revenue Capture</h3><p>Instant lead response, qualification, and booking — 24/7.</p></div>
+          <div class="card hotspot" data-go="systems"><h3>Ops Efficiency</h3><p>Eliminate 20–40 hours of manual work every week.</p></div>
+          <div class="card hotspot" data-go="systems"><h3>Digital Salesman</h3><p>Websites that convert, wired to automated pipelines.</p></div>
+        </div>
+      </section>
+      <div class="cta-band"><h2>Have a specific problem?</h2><p>Reach the founder at vatsal@outpero.com or book an audit.</p><a class="btn btn-gold hotspot" data-go="contact">Book Free Audit</a></div>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="systems" hidden>
+    <div class="frame-wrap" data-frame="sys-desktop" data-page-owner="systems" style="left:80px;top:80px">
+      <div class="frame-label">Revenue systems / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-agency desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class=" hotspot" data-go="home">Home</a><a class=" hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class=" hotspot" data-go="voice">AI Voice Agents</a><a class="active hotspot" data-go="solutions">Solutions</a><a class=" hotspot" data-go="about">About</a><a class=" hotspot" data-go="contact">Contact</a></nav><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></header>
+      <section class="hero" style="text-align:center">
+        <div class="kicker">Revenue systems</div>
+        <h1 class="display">The Big Three</h1>
+        <p class="lede" style="margin:0 auto">End-to-end systems for lead capture, operations, and web. Fixed scope. Fixed price.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="grid-3">
+          <div class="card"><div class="num">System 1</div><h3>Revenue Capture</h3><p>From ₹60,000</p><ul class="checks"><li>AI Voice Agent</li><li>WhatsApp & SMS</li><li>CRM sync</li><li>Missed-call textback</li></ul><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:16px">Get this system</a></div>
+          <div class="card" style="box-shadow:0 0 0 1px #e2b85a, var(--shadow-card)"><span class="flagship">FLAGSHIP</span><div class="num">System 2</div><h3>Ops Efficiency</h3><p>From ₹1,00,000</p><ul class="checks"><li>Process mapping</li><li>3–5 automations</li><li>n8n / Make logic</li><li>Handover docs</li></ul><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:16px">Get this system</a></div>
+          <div class="card"><div class="num">System 3</div><h3>Web Capture</h3><p>From ₹50,000</p><ul class="checks"><li>Landing pages</li><li>Lead capture</li><li>WhatsApp triggers</li><li>Analytics</li></ul><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:16px">Get this system</a></div>
+        </div>
+      </section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="sys-mobile" data-page-owner="systems" style="left:1600px;top:80px">
+      <div class="frame-label">Revenue systems / Mobile</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-agency mobile">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <section class="hero" style="text-align:center">
+        <div class="kicker">Revenue systems</div>
+        <h1 class="display">The Big Three</h1>
+        <p class="lede" style="margin:0 auto">End-to-end systems for lead capture, operations, and web. Fixed scope. Fixed price.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="grid-3">
+          <div class="card"><div class="num">System 1</div><h3>Revenue Capture</h3><p>From ₹60,000</p><ul class="checks"><li>AI Voice Agent</li><li>WhatsApp & SMS</li><li>CRM sync</li><li>Missed-call textback</li></ul><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:16px">Get this system</a></div>
+          <div class="card" style="box-shadow:0 0 0 1px #e2b85a, var(--shadow-card)"><span class="flagship">FLAGSHIP</span><div class="num">System 2</div><h3>Ops Efficiency</h3><p>From ₹1,00,000</p><ul class="checks"><li>Process mapping</li><li>3–5 automations</li><li>n8n / Make logic</li><li>Handover docs</li></ul><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:16px">Get this system</a></div>
+          <div class="card"><div class="num">System 3</div><h3>Web Capture</h3><p>From ₹50,000</p><ul class="checks"><li>Landing pages</li><li>Lead capture</li><li>WhatsApp triggers</li><li>Analytics</li></ul><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:16px">Get this system</a></div>
+        </div>
+      </section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="employee" hidden>
+    <div class="frame-wrap" data-frame="emp-desktop" data-page-owner="employee" style="left:80px;top:80px">
+      <div class="frame-label">AI Employee / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-product desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class=" hotspot" data-go="home">Home</a><a class="active hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class=" hotspot" data-go="voice">AI Voice Agents</a><a class=" hotspot" data-go="solutions">Solutions</a><a class=" hotspot" data-go="about">About</a><a class=" hotspot" data-go="contact">Contact</a></nav><a class="btn btn-gold hotspot" data-go="employee">Hire now</a></header>
+      <section class="hero">
+        <div class="split">
+          <div>
+            <div class="kicker">Andhra & Telangana</div>
+            <h1 class="display">Hire the fastest <span class="telugu" style="color:var(--op-gold)">తెలుగు</span> employee.</h1>
+            <p class="lede">Skip the ₹30k agency setup fee. Hire it yourself in 5 minutes. Native Telugu, English mid-call, dedicated +91 number.</p>
+            <div class="cta-row">
+              <a class="btn btn-gold hotspot" data-go="pricing">See pricing ₹1,899/mo</a>
+              <a class="btn btn-ghost hotspot" data-go="voice">Hear a sample call</a>
+            </div>
+          </div>
+          <div class="diagram">
+            <div class="node core" style="left:50%;top:50%">AI<br>Employee</div>
+            <div class="node" style="left:22%;top:28%">+91 number</div>
+            <div class="node" style="left:80%;top:30%">CRM sync</div>
+            <div class="node" style="left:24%;top:74%">WhatsApp</div>
+            <div class="node" style="left:78%;top:72%">Calendar</div>
+          </div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">One employee, two ways to work.</h2>
+        <div class="grid-2" style="margin-top:24px">
+          <div class="card"><div class="num">01</div><h3>Instant lead calling</h3><p>New Facebook / website lead? The agent calls in seconds, qualifies, and books.</p></div>
+          <div class="card"><div class="num">02</div><h3>Bulk campaigns</h3><p>Launch to thousands at once. Reminders, follow-ups, promo blasts — 24/7.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Who is this best for?</h2>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card"><h3>Real Estate & Builders</h3><p>Call site-visit leads before they bounce to the next listing.</p></div>
+          <div class="card"><h3>Coaching & Admissions</h3><p>Counsel every enquiry the same hour it comes in.</p></div>
+          <div class="card"><h3>Hospitals & Diagnostics</h3><p>Book appointments and never miss a ringing reception line.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Compliance</div>
+        <div class="grid-3" style="margin-top:16px">
+          <div class="card"><h3>DLT numbers</h3><p>Dedicated +91 line, TRAI-aware outbound.</p></div>
+          <div class="card"><h3>DNC screening</h3><p>Indian calling compliance built into the job, not bolted on.</p></div>
+          <div class="card"><h3>Recordings</h3><p>Every call transcribed and stored in Voice Hub.</p></div>
+        </div>
+      </section>
+      <div class="cta-band" style="background:linear-gradient(135deg,#14110a,#3a2a10 50%,#e2b85a)">
+        <h2>Ready in 5 minutes.</h2>
+        <p>No developer. No contract. Pause anytime.</p>
+        <a class="btn btn-gold hotspot" data-go="pricing">Hire an AI employee</a>
+      </div>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="emp-mobile" data-page-owner="employee" style="left:1600px;top:80px">
+      <div class="frame-label">AI Employee / Mobile</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-product mobile">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <section class="hero">
+        <div class="split">
+          <div>
+            <div class="kicker">Andhra & Telangana</div>
+            <h1 class="display">Hire the fastest <span class="telugu" style="color:var(--op-gold)">తెలుగు</span> employee.</h1>
+            <p class="lede">Skip the ₹30k agency setup fee. Hire it yourself in 5 minutes. Native Telugu, English mid-call, dedicated +91 number.</p>
+            <div class="cta-row">
+              <a class="btn btn-gold hotspot" data-go="pricing">See pricing ₹1,899/mo</a>
+              <a class="btn btn-ghost hotspot" data-go="voice">Hear a sample call</a>
+            </div>
+          </div>
+          <div class="diagram">
+            <div class="node core" style="left:50%;top:50%">AI<br>Employee</div>
+            <div class="node" style="left:22%;top:28%">+91 number</div>
+            <div class="node" style="left:80%;top:30%">CRM sync</div>
+            <div class="node" style="left:24%;top:74%">WhatsApp</div>
+            <div class="node" style="left:78%;top:72%">Calendar</div>
+          </div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">One employee, two ways to work.</h2>
+        <div class="grid-2" style="margin-top:24px">
+          <div class="card"><div class="num">01</div><h3>Instant lead calling</h3><p>New Facebook / website lead? The agent calls in seconds, qualifies, and books.</p></div>
+          <div class="card"><div class="num">02</div><h3>Bulk campaigns</h3><p>Launch to thousands at once. Reminders, follow-ups, promo blasts — 24/7.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Who is this best for?</h2>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card"><h3>Real Estate & Builders</h3><p>Call site-visit leads before they bounce to the next listing.</p></div>
+          <div class="card"><h3>Coaching & Admissions</h3><p>Counsel every enquiry the same hour it comes in.</p></div>
+          <div class="card"><h3>Hospitals & Diagnostics</h3><p>Book appointments and never miss a ringing reception line.</p></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="kicker">Compliance</div>
+        <div class="grid-3" style="margin-top:16px">
+          <div class="card"><h3>DLT numbers</h3><p>Dedicated +91 line, TRAI-aware outbound.</p></div>
+          <div class="card"><h3>DNC screening</h3><p>Indian calling compliance built into the job, not bolted on.</p></div>
+          <div class="card"><h3>Recordings</h3><p>Every call transcribed and stored in Voice Hub.</p></div>
+        </div>
+      </section>
+      <div class="cta-band" style="background:linear-gradient(135deg,#14110a,#3a2a10 50%,#e2b85a)">
+        <h2>Ready in 5 minutes.</h2>
+        <p>No developer. No contract. Pause anytime.</p>
+        <a class="btn btn-gold hotspot" data-go="pricing">Hire an AI employee</a>
+      </div>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="pricing" hidden>
+    <div class="frame-wrap" data-frame="price-desktop" data-page-owner="pricing" style="left:80px;top:80px">
+      <div class="frame-label">Pricing / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-product desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class=" hotspot" data-go="home">Home</a><a class="active hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class=" hotspot" data-go="voice">AI Voice Agents</a><a class=" hotspot" data-go="solutions">Solutions</a><a class=" hotspot" data-go="about">About</a><a class=" hotspot" data-go="contact">Contact</a></nav><a class="btn btn-gold hotspot" data-go="employee">Hire now</a></header>
+      <section class="hero" style="text-align:center">
+        <div class="kicker">Pricing</div>
+        <h1 class="display">One price, published.</h1>
+        <p class="lede" style="margin:0 auto">₹1,899 to hire an AI employee for 30 days, plus calls from ₹3 a minute. No setup fee. No sales call to hear the number.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="grid-2">
+          <div class="card" style="text-align:left">
+            <div class="kicker">Hiring fee</div>
+            <h2 class="display">₹1,899 <span style="font-size:18px;opacity:.7">/ 30 days</span></h2>
+            <ul class="checks">
+              <li>1 dedicated AI employee</li>
+              <li>Dedicated +91 DLT number</li>
+              <li>500 credits on every hire</li>
+              <li>+300 bonus on first hire</li>
+              <li>Dashboard, webhooks, CRM</li>
+              <li>99.9% uptime SLA</li>
+            </ul>
+            <a class="btn btn-gold btn-block hotspot" data-go="employee" style="margin-top:18px">Hire now</a>
+          </div>
+          <div>
+            <h3 style="margin-top:0">Voice tiers — pick per employee</h3>
+            <div class="card" style="margin-bottom:10px"><b>Value ₹3/min</b><p>Budget-friendly, covers most day-to-day calling.</p></div>
+            <div class="card" style="margin-bottom:10px"><b>Standard ₹5/min</b><p>A step up in naturalness for everyday quality.</p></div>
+            <div class="card"><b>Premium ₹7/min</b><p>Most lifelike — for the first voice a prospect hears.</p></div>
+          </div>
+        </div>
+        <h2 class="display" style="margin-top:48px">Compared with a telecaller</h2>
+        <table class="table">
+          <tr><th></th><th>Outpero</th><th>Human telecaller</th></tr>
+          <tr><td>Hiring cost</td><td>₹1,899 / 30 days</td><td>₹18,000</td></tr>
+          <tr><td>Hours</td><td>24/7</td><td>One shift</td></tr>
+          <tr><td>Concurrency</td><td>Up to 20</td><td>One</td></tr>
+          <tr><td>Training</td><td>Same day</td><td>2–6 weeks</td></tr>
+        </table>
+      </section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="price-mobile" data-page-owner="pricing" style="left:1600px;top:80px">
+      <div class="frame-label">Pricing / Mobile</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-product mobile">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <section class="hero" style="text-align:center">
+        <div class="kicker">Pricing</div>
+        <h1 class="display">One price, published.</h1>
+        <p class="lede" style="margin:0 auto">₹1,899 to hire an AI employee for 30 days, plus calls from ₹3 a minute. No setup fee. No sales call to hear the number.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <div class="grid-2">
+          <div class="card" style="text-align:left">
+            <div class="kicker">Hiring fee</div>
+            <h2 class="display">₹1,899 <span style="font-size:18px;opacity:.7">/ 30 days</span></h2>
+            <ul class="checks">
+              <li>1 dedicated AI employee</li>
+              <li>Dedicated +91 DLT number</li>
+              <li>500 credits on every hire</li>
+              <li>+300 bonus on first hire</li>
+              <li>Dashboard, webhooks, CRM</li>
+              <li>99.9% uptime SLA</li>
+            </ul>
+            <a class="btn btn-gold btn-block hotspot" data-go="employee" style="margin-top:18px">Hire now</a>
+          </div>
+          <div>
+            <h3 style="margin-top:0">Voice tiers — pick per employee</h3>
+            <div class="card" style="margin-bottom:10px"><b>Value ₹3/min</b><p>Budget-friendly, covers most day-to-day calling.</p></div>
+            <div class="card" style="margin-bottom:10px"><b>Standard ₹5/min</b><p>A step up in naturalness for everyday quality.</p></div>
+            <div class="card"><b>Premium ₹7/min</b><p>Most lifelike — for the first voice a prospect hears.</p></div>
+          </div>
+        </div>
+        <h2 class="display" style="margin-top:48px">Compared with a telecaller</h2>
+        <table class="table">
+          <tr><th></th><th>Outpero</th><th>Human telecaller</th></tr>
+          <tr><td>Hiring cost</td><td>₹1,899 / 30 days</td><td>₹18,000</td></tr>
+          <tr><td>Hours</td><td>24/7</td><td>One shift</td></tr>
+          <tr><td>Concurrency</td><td>Up to 20</td><td>One</td></tr>
+          <tr><td>Training</td><td>Same day</td><td>2–6 weeks</td></tr>
+        </table>
+      </section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="voice" hidden>
+    <div class="frame-wrap" data-frame="voice-desktop" data-page-owner="voice" style="left:80px;top:80px">
+      <div class="frame-label">Voice / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-product desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class=" hotspot" data-go="home">Home</a><a class=" hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class="active hotspot" data-go="voice">AI Voice Agents</a><a class=" hotspot" data-go="solutions">Solutions</a><a class=" hotspot" data-go="about">About</a><a class=" hotspot" data-go="contact">Contact</a></nav><a class="btn btn-gold hotspot" data-go="employee">Hire now</a></header>
+      <section class="hero">
+        <div class="kicker">Telugu-first voice AI</div>
+        <h1 class="display">AI voice agents for Indian businesses.</h1>
+        <p class="lede">Instant lead response. Native Telugu, Hindi, and English. Inbound, outbound, and bulk — one employee.</p>
+        <div class="cta-row">
+          <a class="btn btn-gold hotspot" data-go="employee">Deploy AI Voice Agent</a>
+          <a class="btn btn-ghost">How it works</a>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Hear the AI in action</h2>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card voice-card"><div class="avatar"></div><div><div class="cat">Native Telugu</div><b class="telugu">శాంతి</b><p>Warm & conversational</p></div><div class="play">▶</div></div>
+          <div class="card voice-card"><div class="avatar"></div><div><div class="cat">Native Telugu</div><b class="telugu">Bhaskar</b><p>Energetic & upbeat</p></div><div class="play">▶</div></div>
+          <div class="card voice-card"><div class="avatar"></div><div><div class="cat">Native Telugu</div><b class="telugu">Sahana</b><p>Deep & professional</p></div><div class="play">▶</div></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">How it actually works</h2>
+        <div class="steps" style="margin-top:20px">
+          <div class="card"><div class="step-index">1</div><h3>Lead captured</h3><p>Facebook ad or website form fires.</p></div>
+          <div class="card"><div class="step-index">2</div><h3>3-second call</h3><p>Agent calls before they close the tab.</p></div>
+          <div class="card"><div class="step-index">3</div><h3>Qualifies</h3><p>Handles objections, books the visit.</p></div>
+          <div class="card"><div class="step-index">4</div><h3>Voice Hub</h3><p>Recording, transcript, intent score.</p></div>
+        </div>
+      </section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="voice-mobile" data-page-owner="voice" style="left:1600px;top:80px">
+      <div class="frame-label">Voice / Mobile</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-product mobile">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <section class="hero">
+        <div class="kicker">Telugu-first voice AI</div>
+        <h1 class="display">AI voice agents for Indian businesses.</h1>
+        <p class="lede">Instant lead response. Native Telugu, Hindi, and English. Inbound, outbound, and bulk — one employee.</p>
+        <div class="cta-row">
+          <a class="btn btn-gold hotspot" data-go="employee">Deploy AI Voice Agent</a>
+          <a class="btn btn-ghost">How it works</a>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Hear the AI in action</h2>
+        <div class="grid-3" style="margin-top:20px">
+          <div class="card voice-card"><div class="avatar"></div><div><div class="cat">Native Telugu</div><b class="telugu">శాంతి</b><p>Warm & conversational</p></div><div class="play">▶</div></div>
+          <div class="card voice-card"><div class="avatar"></div><div><div class="cat">Native Telugu</div><b class="telugu">Bhaskar</b><p>Energetic & upbeat</p></div><div class="play">▶</div></div>
+          <div class="card voice-card"><div class="avatar"></div><div><div class="cat">Native Telugu</div><b class="telugu">Sahana</b><p>Deep & professional</p></div><div class="play">▶</div></div>
+        </div>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">How it actually works</h2>
+        <div class="steps" style="margin-top:20px">
+          <div class="card"><div class="step-index">1</div><h3>Lead captured</h3><p>Facebook ad or website form fires.</p></div>
+          <div class="card"><div class="step-index">2</div><h3>3-second call</h3><p>Agent calls before they close the tab.</p></div>
+          <div class="card"><div class="step-index">3</div><h3>Qualifies</h3><p>Handles objections, books the visit.</p></div>
+          <div class="card"><div class="step-index">4</div><h3>Voice Hub</h3><p>Recording, transcript, intent score.</p></div>
+        </div>
+      </section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="compare" hidden>
+    <div class="frame-wrap" data-frame="cmp-desktop" data-page-owner="compare" style="left:80px;top:80px">
+      <div class="frame-label">Compare / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-agency desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class="active hotspot" data-go="home">Home</a><a class=" hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class=" hotspot" data-go="voice">AI Voice Agents</a><a class=" hotspot" data-go="solutions">Solutions</a><a class=" hotspot" data-go="about">About</a><a class=" hotspot" data-go="contact">Contact</a></nav><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></header>
+      <section class="hero">
+        <div class="kicker">Compare</div>
+        <h1 class="display">Sourced, line-by-line comparisons.</h1>
+        <p class="lede">Including a plain statement of where the competitor is genuinely ahead. If a comparison never admits a weakness, it is marketing.</p>
+      </section>
+      <section class="section" style="padding-top:0">
+        <h2 class="display">Regional Telugu & India voice AI</h2>
+        <div class="grid-2" style="margin-top:16px">
+          <div class="card hotspot" data-go="pricing"><h3>Outpero vs Edesy</h3><p>One flat price. No ₹14,999/month tier to unlock an uptime SLA.</p></div>
+          <div class="card"><h3>Outpero vs Zudu AI</h3><p>We publish the number. Their page only offers a demo.</p></div>
+          <div class="card"><h3>Outpero vs Bolna / Vapi</h3><p>Those are developer platforms. This is a finished employee.</p></div>
+          <div class="card"><h3>Outpero vs human telecaller</h3><p>Speed, cost, and concurrency — with a human still on novel cases.</p></div>
+        </div>
+      </section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="blog-desktop" data-page-owner="compare" style="left:1600px;top:80px">
+      <div class="frame-label">Blog / Desktop</div>
+      <div class="artboard desktop" style="width:1440px">
+    <article class="ui theme-agency desktop">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><nav class="nav-links"><a class="active hotspot" data-go="home">Home</a><a class=" hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a><a class=" hotspot" data-go="voice">AI Voice Agents</a><a class=" hotspot" data-go="solutions">Solutions</a><a class=" hotspot" data-go="about">About</a><a class=" hotspot" data-go="contact">Contact</a></nav><a class="btn btn-primary hotspot" data-go="contact">Book Free Audit</a></header>
+      <section class="hero">
+        <div class="kicker">Resources</div>
+        <h1 class="display">Blog</h1>
+        <p class="lede">Voice AI, Telugu calling, pricing, and compliance — written for operators, not developers.</p>
+      </section>
+      <section class="section" style="padding-top:0"><div class="grid-2"><div class="card"><div class="cat">Guide</div><h3>Cheapest AI Voice Agent in India (2026): ₹3/Min</h3><p>Practical, India-specific. No jargon.</p></div><div class="card"><div class="cat">Guide</div><h3>Are AI Calling Agents Legal in India? TRAI, DLT & DNC</h3><p>Practical, India-specific. No jargon.</p></div><div class="card"><div class="cat">Guide</div><h3>Best AI Receptionist for Clinics in AP & Telangana</h3><p>Practical, India-specific. No jargon.</p></div><div class="card"><div class="cat">Guide</div><h3>Telugu AI Voice Agent vs Human Telecaller</h3><p>Practical, India-specific. No jargon.</p></div></div></section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div>
+    <div class="frame-wrap" data-frame="blog-mobile" data-page-owner="compare" style="left:3120px;top:80px">
+      <div class="frame-label">Blog / Mobile</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-agency mobile">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <section class="hero">
+        <div class="kicker">Resources</div>
+        <h1 class="display">Blog</h1>
+        <p class="lede">Voice AI, Telugu calling, pricing, and compliance — written for operators, not developers.</p>
+      </section>
+      <section class="section" style="padding-top:0"><div class="grid-2"><div class="card"><div class="cat">Guide</div><h3>Cheapest AI Voice Agent in India (2026): ₹3/Min</h3><p>Practical, India-specific. No jargon.</p></div><div class="card"><div class="cat">Guide</div><h3>Are AI Calling Agents Legal in India? TRAI, DLT & DNC</h3><p>Practical, India-specific. No jargon.</p></div><div class="card"><div class="cat">Guide</div><h3>Best AI Receptionist for Clinics in AP & Telangana</h3><p>Practical, India-specific. No jargon.</p></div><div class="card"><div class="cat">Guide</div><h3>Telugu AI Voice Agent vs Human Telecaller</h3><p>Practical, India-specific. No jargon.</p></div></div></section>
+      <footer class="footer">
+    <div><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><p class="lede" style="font-size:13px;margin-top:10px">AI automations, voice agents, and web systems — engineered around your outcomes, not our deliverables.</p><p style="font-size:12px;opacity:.6">A product by OpenDG</p></div>
+    <div><b>Navigation</b><a class="hotspot" data-go="home">Home</a><a class="hotspot" data-go="employee">Hire AI Employee</a><a class="hotspot" data-go="voice">AI Voice Agents</a><a class="hotspot" data-go="solutions">Solutions</a><a class="hotspot" data-go="about">About</a></div>
+    <div><b>Resources</b><a class="hotspot" data-go="blog">Blog</a><a class="hotspot" data-go="compare">Compare</a><a class="hotspot" data-go="pricing">Pricing</a></div>
+    <div><b>Get Started</b><p class="lede" style="font-size:13px">Start with a free 30-minute business audit.</p><a class="btn btn-primary hotspot" data-go="contact" style="margin-top:12px">Book Free Audit</a></div>
+    </footer><div class="legal">© 2026 OUTPERO · Privacy · Terms · Refund Policy</div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="menu" hidden>
+    <div class="frame-wrap" data-frame="menu-mobile" data-page-owner="menu" style="left:80px;top:80px">
+      <div class="frame-label">Mobile menu / 390</div>
+      <div class="artboard mobile" style="width:390px">
+    <article class="ui theme-agency mobile" style="position:relative;min-height:844px">
+      <header class="nav"><div class="logo"><span class="logo-mark"><span></span></span>OUTPERO</div><div style="display:flex;gap:8px;align-items:center"><button class="icon-round">☀</button><div class="hamburger hotspot" data-go="menu"><i></i><i></i><i></i></div></div></header>
+      <div class="menu-sheet">
+        <div class="menu-panel">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px"><b>Menu</b><span class="hotspot" data-go="home">✕</span></div>
+          <a class="hotspot" data-go="home">Home</a>
+          <a class="hotspot" data-go="employee">Hire AI Employee <span class="badge-new">NEW</span></a>
+          <a class="hotspot" data-go="voice">AI Voice Agents</a>
+          <a class="hotspot" data-go="solutions">Solutions</a>
+          <a class="hotspot" data-go="about">About</a>
+          <a class="hotspot" data-go="contact">Contact</a>
+          <a class="hotspot" data-go="pricing">Pricing</a>
+          <a class="btn btn-primary btn-block hotspot" data-go="contact" style="margin-top:20px">Book Free Audit</a>
+        </div>
+      </div>
+    </article>
+    </div>
+    </div></div><div class="canvas-page" data-page="flows" hidden>
+    <div class="frame-wrap" data-frame="flows-desktop" data-page-owner="flows" style="left:80px;top:80px">
+      <div class="frame-label">Primary conversion map</div>
+      <div class="artboard desktop" style="width:1440px"><div class="flow"><svg width="1600" height="900" style="position:absolute;inset:0"><g stroke="#a259ff" stroke-width="2" fill="none"><path d="M300 120 H380"/><path d="M300 140 C340 140,340 260,380 260"/><path d="M300 160 C340 160,340 420,380 420"/><path d="M600 100 H700"/><path d="M600 260 H700"/><path d="M600 420 H700"/><path d="M920 420 H1020"/><path d="M920 260 H1020"/></g></svg><div class="flow-node start" style="left:80px;top:80px"><b>Visitor lands</b>Home · 1440 / 390</div><div class="flow-node cta" style="left:380px;top:60px"><b>Book audit</b>Contact form</div><div class="flow-node cta" style="left:380px;top:220px"><b>See systems</b>Revenue systems</div><div class="flow-node cta" style="left:380px;top:380px"><b>Hire employee</b>AI Employee dark</div><div class="flow-node " style="left:700px;top:60px"><b>Audit booked</b>Email + WhatsApp</div><div class="flow-node cta" style="left:700px;top:220px"><b>Pick a system</b>₹50k–1L scope</div><div class="flow-node cta" style="left:700px;top:380px"><b>Pricing</b>₹1899 + ₹3/min</div><div class="flow-node " style="left:1020px;top:380px"><b>Self-serve hire</b>5 min deploy</div><div class="flow-node " style="left:1020px;top:220px"><b>Build in 2 weeks</b>Agency delivery</div><div class="flow-node " style="left:80px;top:560px"><b>Mobile menu</b>Hamburger overlay</div><div class="flow-node " style="left:380px;top:560px"><b>Solutions catalogue</b>19 drop-in SKUs</div><div class="flow-node " style="left:700px;top:560px"><b>Compare / Blog</b>Trust & SEO</div></div></div>
+    </div></div></div>
+      <div class="hint">Space + drag to pan · Scroll to zoom · Prototype mode: click CTAs</div>
+    </main>
+    <aside class="panel panel-right inspect" id="inspect">
+      <h3>Inspect</h3>
+      <p style="color:#aaa;padding:8px 0">Select a frame to see tokens, type, and spacing.</p>
+    </aside>
+  </div>
+  <script src="./js/studio.js"></script>
+</body>
+</html>

--- a/public/ux/outpero/js/studio.js
+++ b/public/ux/outpero/js/studio.js
@@ -1,0 +1,187 @@
+const canvas = document.getElementById("canvas");
+const wrap = document.getElementById("canvasWrap");
+const zoomReadout = document.getElementById("zoomReadout");
+const layersEl = document.getElementById("layers");
+const inspectEl = document.getElementById("inspect");
+
+let scale = 0.32;
+let x = 48;
+let y = 48;
+let page = "cover";
+let selected = null;
+let panning = false;
+let panStart = { x: 0, y: 0, cx: 0, cy: 0 };
+
+function applyTransform() {
+  canvas.style.transform = `translate(${x}px, ${y}px) scale(${scale})`;
+  zoomReadout.textContent = `${Math.round(scale * 100)}%`;
+}
+
+function showPage(id) {
+  page = id;
+  document.querySelectorAll(".canvas-page").forEach((p) => {
+    p.hidden = p.dataset.page !== id;
+  });
+  document.querySelectorAll(".page-item").forEach((b) => {
+    b.classList.toggle("active", b.dataset.page === id);
+  });
+  const frames = [...document.querySelectorAll(`.canvas-page[data-page="${id}"] .frame-wrap`)];
+  layersEl.innerHTML = frames
+    .map(
+      (f) =>
+        `<div class="layer${f.dataset.frame === selected ? " active" : ""}" data-frame="${f.dataset.frame}">${f.querySelector(".frame-label").textContent}</div>`
+    )
+    .join("");
+  selected = frames[0]?.dataset.frame || null;
+  highlight();
+  fit();
+}
+
+function highlight() {
+  document.querySelectorAll(".frame-wrap").forEach((f) => {
+    f.classList.toggle("selected", f.dataset.frame === selected);
+  });
+  document.querySelectorAll(".layer").forEach((l) => {
+    l.classList.toggle("active", l.dataset.frame === selected);
+  });
+  const frame = document.querySelector(`.frame-wrap[data-frame="${selected}"]`);
+  if (!frame) return;
+  const theme = frame.querySelector(".theme-product")
+    ? "Product dark"
+    : frame.querySelector(".theme-agency")
+      ? "Agency light"
+      : "File";
+  inspectEl.innerHTML = `
+    <h3>Inspect</h3>
+    <div class="row"><span>Frame</span><b>${frame.querySelector(".frame-label").textContent}</b></div>
+    <div class="row"><span>Theme</span><b>${theme}</b></div>
+    <div class="row"><span>Width</span><b>${frame.querySelector(".artboard").classList.contains("mobile") ? "390" : "1440"}</b></div>
+    <div class="row"><span>Primary</span><span><i class="swatch" style="background:#7A50DC"></i><span class="token">#7A50DC</span></span></div>
+    <div class="row"><span>Gold</span><span><i class="swatch" style="background:#E2B85A"></i><span class="token">#E2B85A</span></span></div>
+    <div class="row"><span>Cream</span><span><i class="swatch" style="background:#FAF8F5"></i><span class="token">#FAF8F5</span></span></div>
+    <div class="row"><span>Deep</span><span><i class="swatch" style="background:#050505"></i><span class="token">#050505</span></span></div>
+    <div class="row"><span>Display</span><b>Poppins 700</b></div>
+    <div class="row"><span>Body</span><b>Inter 400 / 16</b></div>
+    <div class="row"><span>Radius</span><b>12 / 20 / pill</b></div>
+    <div class="row"><span>CTA</span><b>44px min tap</b></div>
+  `;
+}
+
+function fit() {
+  const pageEl = document.querySelector(`.canvas-page[data-page="${page}"]`);
+  if (!pageEl) return;
+  const frames = [...pageEl.querySelectorAll(".frame-wrap")];
+  if (!frames.length) return;
+  let maxX = 0;
+  let maxY = 0;
+  frames.forEach((f) => {
+    const board = f.querySelector(".artboard");
+    const left = parseFloat(f.style.left);
+    const top = parseFloat(f.style.top);
+    maxX = Math.max(maxX, left + board.offsetWidth);
+    maxY = Math.max(maxY, top + Math.min(board.offsetHeight, 1100));
+  });
+  const pad = 80;
+  const sx = (wrap.clientWidth - pad) / maxX;
+  const sy = (wrap.clientHeight - pad) / Math.max(maxY, 900);
+  scale = Math.max(0.12, Math.min(0.5, Math.min(sx, sy)));
+  x = 40;
+  y = 40;
+  applyTransform();
+}
+
+document.querySelectorAll(".page-item").forEach((btn) => {
+  btn.addEventListener("click", () => showPage(btn.dataset.page));
+});
+
+document.querySelectorAll("[data-mode]").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    document.querySelectorAll("[data-mode]").forEach((b) => b.classList.remove("active"));
+    btn.classList.add("active");
+    document.body.classList.remove("design-mode", "prototype-mode", "inspect-mode");
+    document.body.classList.add(`${btn.dataset.mode}-mode`);
+  });
+});
+
+document.getElementById("zoomIn").onclick = () => {
+  scale = Math.min(1.4, scale * 1.15);
+  applyTransform();
+};
+document.getElementById("zoomOut").onclick = () => {
+  scale = Math.max(0.1, scale / 1.15);
+  applyTransform();
+};
+document.getElementById("zoomFit").onclick = fit;
+
+wrap.addEventListener(
+  "wheel",
+  (e) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.92 : 1.08;
+    scale = Math.min(1.5, Math.max(0.1, scale * delta));
+    applyTransform();
+  },
+  { passive: false }
+);
+
+wrap.addEventListener("pointerdown", (e) => {
+  if (e.button === 1 || e.spaceKey || e.target === wrap || e.target === canvas || e.altKey) {
+    panning = true;
+    wrap.classList.add("panning");
+    panStart = { x: e.clientX, y: e.clientY, cx: x, cy: y };
+  }
+});
+window.addEventListener("pointermove", (e) => {
+  if (!panning) return;
+  x = panStart.cx + (e.clientX - panStart.x);
+  y = panStart.cy + (e.clientY - panStart.y);
+  applyTransform();
+});
+window.addEventListener("pointerup", () => {
+  panning = false;
+  wrap.classList.remove("panning");
+});
+
+let space = false;
+window.addEventListener("keydown", (e) => {
+  if (e.code === "Space") {
+    space = true;
+    wrap.style.cursor = "grab";
+    e.preventDefault();
+  }
+});
+window.addEventListener("keyup", (e) => {
+  if (e.code === "Space") {
+    space = false;
+    wrap.style.cursor = "";
+  }
+});
+wrap.addEventListener("pointerdown", (e) => {
+  if (!space) return;
+  panning = true;
+  wrap.classList.add("panning");
+  panStart = { x: e.clientX, y: e.clientY, cx: x, cy: y };
+});
+
+document.addEventListener("click", (e) => {
+  const layer = e.target.closest(".layer");
+  if (layer) {
+    selected = layer.dataset.frame;
+    highlight();
+    return;
+  }
+  const frame = e.target.closest(".frame-wrap");
+  if (frame && !e.target.closest(".hotspot")) {
+    selected = frame.dataset.frame;
+    highlight();
+  }
+  const hot = e.target.closest(".hotspot");
+  if (hot && document.body.classList.contains("prototype-mode")) {
+    const go = hot.dataset.go;
+    const alias = { menu: "menu", blog: "compare" };
+    if (go) showPage(alias[go] || go);
+  }
+});
+
+showPage("cover");
+window.addEventListener("resize", fit);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What does this PR do?**
Ships an interactive, Figma-like UX file for OUTPERO — high-fidelity **1440 desktop** and **390 mobile** artboards reverse-engineered from [outpero.com](https://outpero.com), not a markdown spec.

Open after deploy: `/ux/outpero/`  
Or open `public/ux/outpero/index.html` locally.

**Type of Change**
- [x] Documentation update (visual UX file)
- [x] New feature (static UX canvas + rewrite)

**What’s in the file**
- Figma-style chrome: pages, layers, pan/zoom, Design / Prototype / Inspect
- **23 frames** across Cover, Design system, Home, Solutions, Contact, About, Revenue systems, Hire AI Employee, Pricing, Voice, Compare + Blog, Mobile menu, User flows
- Two themes from the live site: **Agency cream** (audit/conversion) and **Product cinematic** (AI employee)
- Prototype mode: click CTAs to move between frames (Book Audit → Contact, Hire → Pricing, hamburger → mobile menu)

**How to use it**
1. Open `/ux/outpero/`
2. Browse pages in the left sidebar
3. Switch **Prototype** and click buttons to walk the flows
4. **Inspect** shows tokens (purple `#7A50DC`, gold `#E2B85A`, cream `#FAF8F5`, deep `#050505`)

Figma MCP is not authenticated in this environment, so this is a native Figma-style canvas in the repo. After connecting Figma MCP, these frames can be pushed into a real Figma file.

**Testing**
- [x] Canvas loads with 13 pages / 23 frames
- [x] Rewrite added so `/ux/outpero/` serves the file
- [ ] Preview deploy visual pass on desktop + mobile viewport

**Checklist**
- [x] No markdown spec files
- [x] Self-review of artboard structure and prototype links

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6be7d97-4d43-433a-b7c8-1e3e5597e420?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6be7d97-4d43-433a-b7c8-1e3e5597e420&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

