### PR TITLE
fix: widen ISR revalidate window from 5min to 1h

### DIFF
--- a/src/libs/portfolioData.js
+++ b/src/libs/portfolioData.js
@@ -57,8 +57,14 @@ async function fetchJson(name) {
   const local = readLocal(name);
   if (local) return local;
 
+  // 1h safety-net window: real content edits already trigger an instant full
+  // rebuild via rebuild-portfolio.yml's Vercel deploy hook, so this value only
+  // needs to catch a missed/failed hook — it doesn't buy real-time freshness.
+  // A short window here regenerates every route on every visit past its
+  // staleness point (this fetch runs in root layout.js), which was burning
+  // ISR write quota on ordinary traffic for no freshness benefit.
   const res = await fetch(remoteContentUrl(name), {
-    next: { revalidate: 300 },
+    next: { revalidate: 3600 },
   });
   if (!res.ok) throw new Error(`${name}: HTTP ${res.status}`);
   return res.json();


### PR DESCRIPTION
## Summary
- \`portfolioData.js\` fetches content with \`next: { revalidate: 300 }\`, and this call runs in root \`layout.js\` — so every route on the site inherits a 5-minute ISR window.
- Real content edits already trigger an instant full rebuild via \`rebuild-portfolio.yml\`'s Vercel deploy hook, so the short window bought no real freshness — it only meant any route visited more than 5 min apart regenerated in the background, burning ISR write quota on ordinary traffic.
- Bumped to 1h as a safety-net window (catches a missed/failed deploy hook), not the primary freshness mechanism.

## Test plan
- [x] \`npm test -- portfolioData\` — 68/68 pass
- [ ] Confirm Vercel ISR write usage trends down after this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSWppzE14QfWfvfSpZrMB4